### PR TITLE
Signs and views fix

### DIFF
--- a/Source/tectonicus/TileRenderer.java
+++ b/Source/tectonicus/TileRenderer.java
@@ -1349,7 +1349,7 @@ public class TileRenderer
 			origin.y = (worldVectors.origin.y / scale);
 			json.writeMapsPoint("origin", origin);
 			
-			// Axies
+			// Axes
 			Vector2f xAxis = new Vector2f(worldVectors.xAxis.x / scale, worldVectors.xAxis.y / scale);
 			json.writeMapsPoint("xAxis", xAxis);
 			
@@ -2028,7 +2028,12 @@ public class TileRenderer
 				String posStr = "new WorldCoord("+worldX+", "+worldY+", "+worldZ+")";
 				args.put("worldPos", posStr);
 				
-				String text = sign.getText(1) + " " + sign.getText(2) + " " + sign.getText(3);
+				String text = "";
+				for(int i=1; i<4;i++){
+					if (!sign.getText(i).startsWith("#")){
+						text=text+sign.getText(i);
+					}
+				}
 				text = text.trim();
 				args.put("text", "\'" + jsEscape(text) + "\'");
 				
@@ -2092,10 +2097,13 @@ public class TileRenderer
 	
 	public static String jsEscape(String text)
 	{
-		text = text.replace("\\", "\\\\");	// Replace \ with \\
+		// This is already done in raw.RawChunk.init
+		// Replace spaces only!
+		
+		//text = text.replace("\\", "\\\\");	// Replace \ with \\
 		text = text.replace(" ", "&nbsp;");	// Replace spaces with &nbsp;
-		text = text.replace("\"", "\\\"");	// Replace " with \"
-		text = text.replace("\'", "\\\'");	// Replace ' with \'
+		//text = text.replace("\"", "\\\"");	// Replace " with \"
+		//text = text.replace("\'", "\\\'");	// Replace ' with \'
 		
 		return text;
 	}

--- a/Source/tectonicus/ViewUtil.java
+++ b/Source/tectonicus/ViewUtil.java
@@ -50,11 +50,14 @@ public class ViewUtil
 	{
 		String toParse = sign.getText(0);
 		
-		if (sign.getText(1).startsWith("#"))
-			toParse += " " + sign.getText(1);
+		if (sign.getText(1).startsWith("#") && sign.getText(1).length()>1)
+			toParse += " " + sign.getText(1).substring(1);
 		
-		if (sign.getText(2).startsWith("#"))
-			toParse += " " + sign.getText(2);
+		if (sign.getText(2).startsWith("#") && sign.getText(2).length()>1)
+			toParse += " " + sign.getText(2).substring(1);
+		
+		if (sign.getText(3).startsWith("#") && sign.getText(3).length()>1)
+			toParse += " " + sign.getText(3).substring(1);
 		
 		Set<String> settings = new HashSet<String>();
 		

--- a/Source/tectonicus/raw/RawChunk.java
+++ b/Source/tectonicus/raw/RawChunk.java
@@ -112,7 +112,7 @@ public class RawChunk
 	private void init(InputStream in, Compression compression) throws Exception
 	{
 		clear();
-		
+
 		NBTInputStream nbtIn = null;
 		try
 		{
@@ -293,30 +293,31 @@ public class RawChunk
 										String text2 = NbtUtil.getChild(entity, "Text2", StringTag.class).getValue();
 										String text3 = NbtUtil.getChild(entity, "Text3", StringTag.class).getValue();
 										String text4 = NbtUtil.getChild(entity, "Text4", StringTag.class).getValue();
+
 										
 										if (!text1.isEmpty() && FileUtils.isJSONValid(text1))
 										{
-											text1 = text1.replaceAll("^[{]|[}]$", "").split(":", 2)[1];
-											text2 = text2.replaceAll("^[{]|[}]$", "").split(":", 2)[1];
-											text3 = text3.replaceAll("^[{]|[}]$", "").split(":", 2)[1];
-											text4 = text4.replaceAll("^[{]|[}]$", "").split(":", 2)[1];
+											text1=textFromJSON(text1);
+											text2=textFromJSON(text2);
+											text3=textFromJSON(text3);
+											text4=textFromJSON(text4);
 										}
+										else{ 
 
-										text1 = text1.replaceAll("^\"|\"$", "");  //This regex removes begin and end double quotes
-										if (text1 == null || text1.equals("null"))
-											text1 = "";
+											text1 = text1.replaceAll("^\"|\"$", "");  //This regex removes begin and end double quotes
+											if (text1 == null || text1.equals("null"))
+												text1 = "";
+											text2 = text2.replaceAll("^\"|\"$", "");
+											if (text2 == null || text2.equals("null"))
+												text2 = "";
+											text3 = text3.replaceAll("^\"|\"$", "");
+											if (text3 == null || text3.equals("null"))
+												text3 = "";
+											text4 = text4.replaceAll("^\"|\"$", "");
+											if (text4 == null || text4.equals("null"))
+												text4 = "";
+										}
 										
-										text2 = text2.replaceAll("^\"|\"$", "");
-										if (text2 == null || text2.equals("null"))
-											text2 = "";
-										
-										text3 = text3.replaceAll("^\"|\"$", "");
-										if (text3 == null || text3.equals("null"))
-											text3 = "";
-										
-										text4 = text4.replaceAll("^\"|\"$", "");
-										if (text4 == null || text4.equals("null"))
-											text4 = "";
 										
 										final int x = xTag.getValue();
 										final int y = yTag.getValue();
@@ -1045,6 +1046,42 @@ public class RawChunk
 			skylight = new byte[SECTION_WIDTH][SECTION_HEIGHT][SECTION_DEPTH];
 			blocklight = new byte[SECTION_WIDTH][SECTION_HEIGHT][SECTION_DEPTH];
 		}
+	}
+	
+	private static String textFromJSON(String rawMessage){
+		String result="";
+		String searchString = "\"text\":\"";
+		int pos=0;
+		int left=0;
+		int right=0;
+		while(pos != -1){
+			pos=rawMessage.indexOf(searchString, pos);
+			left=pos+8;
+			if(pos != -1){
+				int nBackslash=0;
+				// Find right delimiting ". Problem: \\\" is escaped, \\\\" is not.
+				for(int i=left; i<rawMessage.length(); i++){ 
+					if(rawMessage.charAt(i)=='\\'){
+						nBackslash++;
+					}
+					else if(rawMessage.charAt(i)=='"' && nBackslash % 2 == 0){
+						right=i;
+						break;
+					}
+					else{
+						nBackslash=0;
+					}
+	
+				}
+
+				result=result+rawMessage.substring(left, right);
+				pos=left;
+			}
+			
+		}
+		
+		
+		return result;
 	}
 
 }


### PR DESCRIPTION
This branch fixes #70  and some other issues.

1. As written there, my signs created with Spigot 1.9 contain this raw data:
<pre>Text1: {"text":""}
Text2: {"extra":[{"text":"SparkLake"}]},"text":""}
Text3: {"extra":[{"text":"City"}]},"text":""}
Text4: {"text":""}</pre>
Though the `extra` key is not used by vanilla MC, it yet is standard and allows e.g. colored text. Now, Tectonicus searches for all `"text"` keys and  concatenates their values. Escaped characters are handled correctly.

2. For view descriptions, special characters were escaped twice / without checking if needed. This caused additional `\` and ignored unicode characters (`\u003c` was replaced by `\\u003c`, which is displayed as `\u003c` instead of `<`)

3. View descriptions were always created from lines 2-4, though line 2 could contain view parameters. Now, descriptions are only created from lines not starting with `#`.

4. View parameters can be written to all four lines, and the white space between `#` and parameter isn't necessary any more (i.e. `#h10` in second line is fine now)