### PR TITLE
Armor stands, paletted permutations, elemental paintings, chiseled bookshelves

### DIFF
--- a/src/main/java/tectonicus/BlockRegistryParser.java
+++ b/src/main/java/tectonicus/BlockRegistryParser.java
@@ -17,6 +17,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import tectonicus.blockTypes.Air;
 import tectonicus.blockTypes.Anvil;
+import tectonicus.blockTypes.ArmorStand;
 import tectonicus.blockTypes.Banner;
 import tectonicus.blockTypes.Beacon;
 import tectonicus.blockTypes.Bed;
@@ -889,6 +890,9 @@ public class BlockRegistryParser
                 }
                 else if (nodeName.equals("chiseledbookshelf")) {
                         blockType = new ChiseledBookshelf(name, texturePack);
+                }
+                else if (nodeName.equals("armorstand")) {
+                        blockType = new ArmorStand(name, texturePack);
                 }
 		else
 		{

--- a/src/main/java/tectonicus/BlockRegistryParser.java
+++ b/src/main/java/tectonicus/BlockRegistryParser.java
@@ -30,6 +30,7 @@ import tectonicus.blockTypes.Carpet;
 import tectonicus.blockTypes.Cauldron;
 import tectonicus.blockTypes.Chest;
 import tectonicus.blockTypes.ChestNew;
+import tectonicus.blockTypes.ChiseledBookshelf;
 import tectonicus.blockTypes.ChorusFlower;
 import tectonicus.blockTypes.ChorusPlant;
 import tectonicus.blockTypes.CocoaPod;
@@ -885,6 +886,9 @@ public class BlockRegistryParser
 		}
                 else if (nodeName.equals("decoratedpot")) {
                         blockType = new DecoratedPot(name, texturePack);
+                }
+                else if (nodeName.equals("chiseledbookshelf")) {
+                        blockType = new ChiseledBookshelf(name, texturePack);
                 }
 		else
 		{

--- a/src/main/java/tectonicus/BlockRegistryParser.java
+++ b/src/main/java/tectonicus/BlockRegistryParser.java
@@ -884,36 +884,7 @@ public class BlockRegistryParser
 			blockType = new Bell(name, stringId, texture);
 		}
                 else if (nodeName.equals("decoratedpot")) {
-                        final SubTexture baseTexture = texturePack.findTextureOrDefault("assets/minecraft/textures/entity/decorated_pot/decorated_pot_base.png", null);
-                        final HashMap<String, SubTexture> textures = new HashMap<>();
-                        
-                        textures.put("minecraft:brick", texturePack.findTextureOrDefault("assets/minecraft/textures/entity/decorated_pot/decorated_pot_side.png", null));
-                        for (var pattern : new String[] {
-                            "angler",
-                            "archer",
-                            "arms_up",
-                            "blade",
-                            "brewer",
-                            "burn",
-                            "danger",
-                            "explorer",
-                            "friend",
-                            "heart",
-                            "heartbreak",
-                            "howl",
-                            "miner",
-                            "mourner",
-                            "plenty",
-                            "prize",
-                            "sheaf",
-                            "shelter",
-                            "skull",
-                            "snort"
-                        }) {
-                                textures.put("minecraft:"+pattern+"_pottery_sherd", texturePack.findTextureOrDefault("assets/minecraft/textures/entity/decorated_pot/"+pattern+"_pottery_pattern.png", null));
-                        }
-                        
-                        blockType = new DecoratedPot(name, baseTexture, textures);
+                        blockType = new DecoratedPot(name, texturePack);
                 }
 		else
 		{

--- a/src/main/java/tectonicus/blockTypes/ArmorStand.java
+++ b/src/main/java/tectonicus/blockTypes/ArmorStand.java
@@ -336,9 +336,103 @@ public class ArmorStand implements BlockType
         }
         
         private void buildFeetArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier) {
+                final float widthTexel = 1.0f / 64.0f;
+		final float heightTexel = 1.0f / 32.0f;
+    
+                SubMesh mesh = new SubMesh();
+
+                
+                // Left foot (this one is "turned inside out" to produce mirror image of right foot)
+
+                // Front
+		mesh.addDoubleSidedQuad(new Vector3f(12.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(7.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(7.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*4, texture.v0+heightTexel*20, texture.u0+widthTexel*8, texture.v0+heightTexel*32));
+		// Back
+		mesh.addDoubleSidedQuad(new Vector3f(7.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(7.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*20, texture.u0+widthTexel*16, texture.v0+heightTexel*32));
+		// Left edge
+		mesh.addDoubleSidedQuad(new Vector3f(7.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(7.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(7.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(7.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*8, texture.v0+heightTexel*20, texture.u0+widthTexel*12, texture.v0+heightTexel*32));
+		// Right edge
+		mesh.addDoubleSidedQuad(new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*20, texture.u0+widthTexel*4, texture.v0+heightTexel*32));
+
+
+                // Right foot
+
+                // Front
+		mesh.addDoubleSidedQuad(new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*4, texture.v0+heightTexel*20, texture.u0+widthTexel*8, texture.v0+heightTexel*32));
+		// Back
+		mesh.addDoubleSidedQuad(new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*20, texture.u0+widthTexel*16, texture.v0+heightTexel*32));
+		// Left edge
+		mesh.addDoubleSidedQuad(new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*20, texture.u0+widthTexel*4, texture.v0+heightTexel*32));
+		// Right edge
+		mesh.addDoubleSidedQuad(new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 13.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(8.5f*UNIT+offsetMultiplier*EPSILON, 0.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*8, texture.v0+heightTexel*20, texture.u0+widthTexel*12, texture.v0+heightTexel*32));
+                
+		
+                mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.AlphaTest), x, y, z, Rotation.AntiClockwise, angle);
         }
         
         private void buildLegsArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier) {
+                final float widthTexel = 1.0f / 64.0f;
+		final float heightTexel = 1.0f / 32.0f;
+                
+                offsetMultiplier += 1; // To be slightly bigger than the stand and not overlap
+    
+                SubMesh mesh = new SubMesh();
+
+                
+                // Front
+		mesh.addDoubleSidedQuad(new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*20, texture.v0+heightTexel*27, texture.u0+widthTexel*28, texture.v0+heightTexel*32));
+		// Back
+		mesh.addDoubleSidedQuad(new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*32, texture.v0+heightTexel*27, texture.u0+widthTexel*40, texture.v0+heightTexel*32));
+		// Left edge
+		mesh.addDoubleSidedQuad(new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*16, texture.v0+heightTexel*27, texture.u0+widthTexel*20, texture.v0+heightTexel*32));
+		// Right edge
+		mesh.addDoubleSidedQuad(new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 17*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 12*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*28, texture.v0+heightTexel*27, texture.u0+widthTexel*32, texture.v0+heightTexel*32));
+
+                
+                // Left leg (this one is "turned inside out" to produce mirror image of right leg)
+
+                // Front
+		mesh.addDoubleSidedQuad(new Vector3f(12*UNIT-offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT-offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*4, texture.v0+heightTexel*20, texture.u0+widthTexel*8, texture.v0+heightTexel*32));
+		// Back
+		mesh.addDoubleSidedQuad(new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT-offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT-offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*20, texture.u0+widthTexel*16, texture.v0+heightTexel*32));
+		// Left edge
+		mesh.addDoubleSidedQuad(new Vector3f(8*UNIT-offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 10*UNIT-offsetMultiplier*EPSILON), new Vector3f(8*UNIT-offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 6*UNIT+offsetMultiplier*EPSILON), new Vector3f(8*UNIT-offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 6*UNIT+offsetMultiplier*EPSILON), new Vector3f(8*UNIT-offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 10*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*8, texture.v0+heightTexel*20, texture.u0+widthTexel*12, texture.v0+heightTexel*32));
+		// Right edge
+		mesh.addDoubleSidedQuad(new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 6*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 13*UNIT-offsetMultiplier*EPSILON, 10*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 10*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 1*UNIT+offsetMultiplier*EPSILON, 6*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*20, texture.u0+widthTexel*4, texture.v0+heightTexel*32));
+
+
+                // Right leg
+
+                // Front
+		mesh.addDoubleSidedQuad(new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*4, texture.v0+heightTexel*20, texture.u0+widthTexel*8, texture.v0+heightTexel*32));
+		// Back
+		mesh.addDoubleSidedQuad(new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*20, texture.u0+widthTexel*16, texture.v0+heightTexel*32));
+		// Left edge
+		mesh.addDoubleSidedQuad(new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*20, texture.u0+widthTexel*4, texture.v0+heightTexel*32));
+		// Right edge
+		mesh.addDoubleSidedQuad(new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 13*UNIT+offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 6*UNIT-offsetMultiplier*EPSILON), new Vector3f(8*UNIT+offsetMultiplier*EPSILON, 1*UNIT-offsetMultiplier*EPSILON, 10*UNIT+offsetMultiplier*EPSILON), colour,
+                        new SubTexture(texture.texture, texture.u0+widthTexel*8, texture.v0+heightTexel*20, texture.u0+widthTexel*12, texture.v0+heightTexel*32));
+                
+		
+                mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.AlphaTest), x, y, z, Rotation.AntiClockwise, angle);
         }
         
         private void buildChestArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier) {

--- a/src/main/java/tectonicus/blockTypes/ArmorStand.java
+++ b/src/main/java/tectonicus/blockTypes/ArmorStand.java
@@ -20,6 +20,7 @@ import tectonicus.raw.ArmorItem;
 import tectonicus.raw.ArmorStandEntity;
 import tectonicus.raw.DisplayTag;
 import tectonicus.raw.RawChunk;
+import tectonicus.raw.SkullEntity;
 import tectonicus.renderer.Geometry;
 import tectonicus.texture.SubTexture;
 import tectonicus.texture.TexturePack;
@@ -27,9 +28,10 @@ import tectonicus.texture.TexturePack;
 public class ArmorStand implements BlockType
 {
         private interface ArmorMeshBuilder {
-                void build(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle, SubTexture texture, int offsetMultiplier);
+                void build(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier);
         }
     
+        private static final float UNIT = 1.0f / 16.0f;
         private static final float EPSILON = 0.005f / 16.0f; // So that different layer textures are not on the same plane
     
 	private final String name;
@@ -106,14 +108,12 @@ public class ArmorStand implements BlockType
                         z = entity.getLocalZ();
                     
                         final Vector4f colour = new Vector4f(1, 1, 1, 1);
-                        final float unit = 1.0f / 16.0f;
-                        final float angle = entity.getYaw();
 
                         if (!entity.getInvisible() && !entity.getNoBasePlate()) {
-                                buildBaseMesh(x, y, z, geometry, colour, unit);
+                                buildBaseMesh(x, y, z, geometry, colour);
                         }
                         if (!entity.getInvisible()) {
-                                buildStandMesh(x, y, z, geometry, colour, unit, angle);
+                                buildStandMesh(x, y, z, geometry, colour, entity.getYaw());
                         }
                         
                         ArmorItem feetArmor = entity.getFeetArmor();
@@ -122,145 +122,154 @@ public class ArmorStand implements BlockType
                         ArmorItem headArmor = entity.getHeadArmor();
                         
                         if (feetArmor != null) {
-                                buildArmorMesh(x, y, z, geometry, colour, unit, angle, feetArmor, (byte)1, this::buildFeetArmorMesh);
+                                buildArmorMesh(x, y, z, world, registry, rawChunk, geometry, entity, colour, feetArmor, (byte)1, this::buildFeetArmorMesh);
                         }
                         if (legsArmor != null) {
-                                buildArmorMesh(x, y, z, geometry, colour, unit, angle, legsArmor, (byte)2, this::buildLegsArmorMesh);
+                                buildArmorMesh(x, y, z, world, registry, rawChunk, geometry, entity, colour, legsArmor, (byte)2, this::buildLegsArmorMesh);
                         }
                         if (chestArmor != null) {
-                                buildArmorMesh(x, y, z, geometry, colour, unit, angle, chestArmor, (byte)1, this::buildChestArmorMesh);
+                                buildArmorMesh(x, y, z, world, registry, rawChunk, geometry, entity, colour, chestArmor, (byte)1, this::buildChestArmorMesh);
                         }
                         if (headArmor != null) {
-                                buildArmorMesh(x, y, z, geometry, colour, unit, angle, headArmor, (byte)1, this::buildHeadArmorMesh);
+                                buildArmorMesh(x, y, z, world, registry, rawChunk, geometry, entity, colour, headArmor, (byte)1, this::buildHeadArmorMesh);
                         }
                 }
 	}
         
-        private void buildBaseMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit) {
+        private void buildBaseMesh(int x, int y, int z, Geometry geometry, Vector4f colour) {
                 SubMesh mesh = new SubMesh();
 		
 		// Front
-		mesh.addQuad(new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(2*UNIT, 1*UNIT, 14*UNIT), new Vector3f(14*UNIT, 1*UNIT, 14*UNIT), new Vector3f(14*UNIT, 0*UNIT, 14*UNIT), new Vector3f(2*UNIT, 0*UNIT, 14*UNIT), colour, baseSideTexture);
 		// Back
-		mesh.addQuad(new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(14*UNIT, 1*UNIT, 2*UNIT), new Vector3f(2*UNIT, 1*UNIT, 2*UNIT), new Vector3f(2*UNIT, 0*UNIT, 2*UNIT), new Vector3f(14*UNIT, 0*UNIT, 2*UNIT), colour, baseSideTexture);
 		// Top
-		mesh.addQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(2*unit, 1*unit, 14*unit), colour, baseTopTexture);
+		mesh.addQuad(new Vector3f(2*UNIT, 1*UNIT, 2*UNIT), new Vector3f(14*UNIT, 1*UNIT, 2*UNIT), new Vector3f(14*UNIT, 1*UNIT, 14*UNIT), new Vector3f(2*UNIT, 1*UNIT, 14*UNIT), colour, baseTopTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 2*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(2*UNIT, 1*UNIT, 2*UNIT), new Vector3f(2*UNIT, 1*UNIT, 14*UNIT), new Vector3f(2*UNIT, 0*UNIT, 14*UNIT), new Vector3f(2*UNIT, 0*UNIT, 2*UNIT), colour, baseSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 14*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(14*UNIT, 1*UNIT, 14*UNIT), new Vector3f(14*UNIT, 1*UNIT, 2*UNIT), new Vector3f(14*UNIT, 0*UNIT, 2*UNIT), new Vector3f(14*UNIT, 0*UNIT, 14*UNIT), colour, baseSideTexture);
 		
                 mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.None, 0);
         }
 
-        private void buildStandMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle) {
+        private void buildStandMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle) {
                 SubMesh mesh = new SubMesh();
 
 
                 // Left leg
                 
 		// Front
-		mesh.addQuad(new Vector3f(5*unit, 12*unit, 9*unit), new Vector3f(7*unit, 12*unit, 9*unit), new Vector3f(7*unit, 1*unit, 9*unit), new Vector3f(5*unit, 1*unit, 9*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(5*UNIT, 12*UNIT, 9*UNIT), new Vector3f(7*UNIT, 12*UNIT, 9*UNIT), new Vector3f(7*UNIT, 1*UNIT, 9*UNIT), new Vector3f(5*UNIT, 1*UNIT, 9*UNIT), colour, legSideTexture);
 		// Back
-		mesh.addQuad(new Vector3f(7*unit, 12*unit, 7*unit), new Vector3f(5*unit, 12*unit, 7*unit), new Vector3f(5*unit, 1*unit, 7*unit), new Vector3f(7*unit, 1*unit, 7*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(7*UNIT, 12*UNIT, 7*UNIT), new Vector3f(5*UNIT, 12*UNIT, 7*UNIT), new Vector3f(5*UNIT, 1*UNIT, 7*UNIT), new Vector3f(7*UNIT, 1*UNIT, 7*UNIT), colour, legSideTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(5*unit, 12*unit, 7*unit), new Vector3f(5*unit, 12*unit, 9*unit), new Vector3f(5*unit, 1*unit, 9*unit), new Vector3f(5*unit, 1*unit, 7*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(5*UNIT, 12*UNIT, 7*UNIT), new Vector3f(5*UNIT, 12*UNIT, 9*UNIT), new Vector3f(5*UNIT, 1*UNIT, 9*UNIT), new Vector3f(5*UNIT, 1*UNIT, 7*UNIT), colour, legSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(7*unit, 12*unit, 9*unit), new Vector3f(7*unit, 12*unit, 7*unit), new Vector3f(7*unit, 1*unit, 7*unit), new Vector3f(7*unit, 1*unit, 9*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(7*UNIT, 12*UNIT, 9*UNIT), new Vector3f(7*UNIT, 12*UNIT, 7*UNIT), new Vector3f(7*UNIT, 1*UNIT, 7*UNIT), new Vector3f(7*UNIT, 1*UNIT, 9*UNIT), colour, legSideTexture);
 
 
                 // Right leg
                 
 		// Front
-		mesh.addQuad(new Vector3f(9*unit, 12*unit, 9*unit), new Vector3f(11*unit, 12*unit, 9*unit), new Vector3f(11*unit, 1*unit, 9*unit), new Vector3f(9*unit, 1*unit, 9*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(9*UNIT, 12*UNIT, 9*UNIT), new Vector3f(11*UNIT, 12*UNIT, 9*UNIT), new Vector3f(11*UNIT, 1*UNIT, 9*UNIT), new Vector3f(9*UNIT, 1*UNIT, 9*UNIT), colour, legSideTexture);
 		// Back
-		mesh.addQuad(new Vector3f(11*unit, 12*unit, 7*unit), new Vector3f(9*unit, 12*unit, 7*unit), new Vector3f(9*unit, 1*unit, 7*unit), new Vector3f(11*unit, 1*unit, 7*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(11*UNIT, 12*UNIT, 7*UNIT), new Vector3f(9*UNIT, 12*UNIT, 7*UNIT), new Vector3f(9*UNIT, 1*UNIT, 7*UNIT), new Vector3f(11*UNIT, 1*UNIT, 7*UNIT), colour, legSideTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(9*unit, 12*unit, 7*unit), new Vector3f(9*unit, 12*unit, 9*unit), new Vector3f(9*unit, 1*unit, 9*unit), new Vector3f(9*unit, 1*unit, 7*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(9*UNIT, 12*UNIT, 7*UNIT), new Vector3f(9*UNIT, 12*UNIT, 9*UNIT), new Vector3f(9*UNIT, 1*UNIT, 9*UNIT), new Vector3f(9*UNIT, 1*UNIT, 7*UNIT), colour, legSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(11*unit, 12*unit, 9*unit), new Vector3f(11*unit, 12*unit, 7*unit), new Vector3f(11*unit, 1*unit, 7*unit), new Vector3f(11*unit, 1*unit, 9*unit), colour, legSideTexture);
+		mesh.addQuad(new Vector3f(11*UNIT, 12*UNIT, 9*UNIT), new Vector3f(11*UNIT, 12*UNIT, 7*UNIT), new Vector3f(11*UNIT, 1*UNIT, 7*UNIT), new Vector3f(11*UNIT, 1*UNIT, 9*UNIT), colour, legSideTexture);
 
                 
                 // Hips
                 
 		// Front
-		mesh.addQuad(new Vector3f(4*unit, 14*unit, 9*unit), new Vector3f(12*unit, 14*unit, 9*unit), new Vector3f(12*unit, 12*unit, 9*unit), new Vector3f(4*unit, 12*unit, 9*unit), colour, hipsFrontTexture);
+		mesh.addQuad(new Vector3f(4*UNIT, 14*UNIT, 9*UNIT), new Vector3f(12*UNIT, 14*UNIT, 9*UNIT), new Vector3f(12*UNIT, 12*UNIT, 9*UNIT), new Vector3f(4*UNIT, 12*UNIT, 9*UNIT), colour, hipsFrontTexture);
 		// Back
-		mesh.addQuad(new Vector3f(12*unit, 14*unit, 7*unit), new Vector3f(4*unit, 14*unit, 7*unit), new Vector3f(4*unit, 12*unit, 7*unit), new Vector3f(12*unit, 12*unit, 7*unit), colour, hipsFrontTexture);
+		mesh.addQuad(new Vector3f(12*UNIT, 14*UNIT, 7*UNIT), new Vector3f(4*UNIT, 14*UNIT, 7*UNIT), new Vector3f(4*UNIT, 12*UNIT, 7*UNIT), new Vector3f(12*UNIT, 12*UNIT, 7*UNIT), colour, hipsFrontTexture);
 		// Top
-		mesh.addQuad(new Vector3f(4*unit, 14*unit, 7*unit), new Vector3f(12*unit, 14*unit, 7*unit), new Vector3f(12*unit, 14*unit, 9*unit), new Vector3f(4*unit, 14*unit, 9*unit), colour, hipsFrontTexture);
+		mesh.addQuad(new Vector3f(4*UNIT, 14*UNIT, 7*UNIT), new Vector3f(12*UNIT, 14*UNIT, 7*UNIT), new Vector3f(12*UNIT, 14*UNIT, 9*UNIT), new Vector3f(4*UNIT, 14*UNIT, 9*UNIT), colour, hipsFrontTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(4*unit, 14*unit, 7*unit), new Vector3f(4*unit, 14*unit, 9*unit), new Vector3f(4*unit, 12*unit, 9*unit), new Vector3f(4*unit, 12*unit, 7*unit), colour, hipsSideTexture);
+		mesh.addQuad(new Vector3f(4*UNIT, 14*UNIT, 7*UNIT), new Vector3f(4*UNIT, 14*UNIT, 9*UNIT), new Vector3f(4*UNIT, 12*UNIT, 9*UNIT), new Vector3f(4*UNIT, 12*UNIT, 7*UNIT), colour, hipsSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(12*unit, 14*unit, 9*unit), new Vector3f(12*unit, 14*unit, 7*unit), new Vector3f(12*unit, 12*unit, 7*unit), new Vector3f(12*unit, 12*unit, 9*unit), colour, hipsSideTexture);
+		mesh.addQuad(new Vector3f(12*UNIT, 14*UNIT, 9*UNIT), new Vector3f(12*UNIT, 14*UNIT, 7*UNIT), new Vector3f(12*UNIT, 12*UNIT, 7*UNIT), new Vector3f(12*UNIT, 12*UNIT, 9*UNIT), colour, hipsSideTexture);
 
 
                 // Left part of torso
                 
 		// Front
-		mesh.addQuad(new Vector3f(5*unit, 21*unit, 9*unit), new Vector3f(7*unit, 21*unit, 9*unit), new Vector3f(7*unit, 14*unit, 9*unit), new Vector3f(5*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(5*UNIT, 21*UNIT, 9*UNIT), new Vector3f(7*UNIT, 21*UNIT, 9*UNIT), new Vector3f(7*UNIT, 14*UNIT, 9*UNIT), new Vector3f(5*UNIT, 14*UNIT, 9*UNIT), colour, torsoSideTexture);
 		// Back
-		mesh.addQuad(new Vector3f(7*unit, 21*unit, 7*unit), new Vector3f(5*unit, 21*unit, 7*unit), new Vector3f(5*unit, 14*unit, 7*unit), new Vector3f(7*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(7*UNIT, 21*UNIT, 7*UNIT), new Vector3f(5*UNIT, 21*UNIT, 7*UNIT), new Vector3f(5*UNIT, 14*UNIT, 7*UNIT), new Vector3f(7*UNIT, 14*UNIT, 7*UNIT), colour, torsoSideTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(5*unit, 21*unit, 7*unit), new Vector3f(5*unit, 21*unit, 9*unit), new Vector3f(5*unit, 14*unit, 9*unit), new Vector3f(5*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(5*UNIT, 21*UNIT, 7*UNIT), new Vector3f(5*UNIT, 21*UNIT, 9*UNIT), new Vector3f(5*UNIT, 14*UNIT, 9*UNIT), new Vector3f(5*UNIT, 14*UNIT, 7*UNIT), colour, torsoSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(7*unit, 21*unit, 9*unit), new Vector3f(7*unit, 21*unit, 7*unit), new Vector3f(7*unit, 14*unit, 7*unit), new Vector3f(7*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(7*UNIT, 21*UNIT, 9*UNIT), new Vector3f(7*UNIT, 21*UNIT, 7*UNIT), new Vector3f(7*UNIT, 14*UNIT, 7*UNIT), new Vector3f(7*UNIT, 14*UNIT, 9*UNIT), colour, torsoSideTexture);
 
 
                 // Right part of torso
                 
 		// Front
-		mesh.addQuad(new Vector3f(9*unit, 21*unit, 9*unit), new Vector3f(11*unit, 21*unit, 9*unit), new Vector3f(11*unit, 14*unit, 9*unit), new Vector3f(9*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(9*UNIT, 21*UNIT, 9*UNIT), new Vector3f(11*UNIT, 21*UNIT, 9*UNIT), new Vector3f(11*UNIT, 14*UNIT, 9*UNIT), new Vector3f(9*UNIT, 14*UNIT, 9*UNIT), colour, torsoSideTexture);
 		// Back
-		mesh.addQuad(new Vector3f(11*unit, 21*unit, 7*unit), new Vector3f(9*unit, 21*unit, 7*unit), new Vector3f(9*unit, 14*unit, 7*unit), new Vector3f(11*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(11*UNIT, 21*UNIT, 7*UNIT), new Vector3f(9*UNIT, 21*UNIT, 7*UNIT), new Vector3f(9*UNIT, 14*UNIT, 7*UNIT), new Vector3f(11*UNIT, 14*UNIT, 7*UNIT), colour, torsoSideTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(9*unit, 21*unit, 7*unit), new Vector3f(9*unit, 21*unit, 9*unit), new Vector3f(9*unit, 14*unit, 9*unit), new Vector3f(9*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(9*UNIT, 21*UNIT, 7*UNIT), new Vector3f(9*UNIT, 21*UNIT, 9*UNIT), new Vector3f(9*UNIT, 14*UNIT, 9*UNIT), new Vector3f(9*UNIT, 14*UNIT, 7*UNIT), colour, torsoSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(11*unit, 21*unit, 9*unit), new Vector3f(11*unit, 21*unit, 7*unit), new Vector3f(11*unit, 14*unit, 7*unit), new Vector3f(11*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+		mesh.addQuad(new Vector3f(11*UNIT, 21*UNIT, 9*UNIT), new Vector3f(11*UNIT, 21*UNIT, 7*UNIT), new Vector3f(11*UNIT, 14*UNIT, 7*UNIT), new Vector3f(11*UNIT, 14*UNIT, 9*UNIT), colour, torsoSideTexture);
 
                 
                 // Shoulders
                 
 		// Front
-		mesh.addQuad(new Vector3f(2*unit, 24*unit, 9.5f*unit), new Vector3f(14*unit, 24*unit, 9.5f*unit), new Vector3f(14*unit, 21*unit, 9.5f*unit), new Vector3f(2*unit, 21*unit, 9.5f*unit), colour, shouldersFrontTexture);
+		mesh.addQuad(new Vector3f(2*UNIT, 24*UNIT, 9.5f*UNIT), new Vector3f(14*UNIT, 24*UNIT, 9.5f*UNIT), new Vector3f(14*UNIT, 21*UNIT, 9.5f*UNIT), new Vector3f(2*UNIT, 21*UNIT, 9.5f*UNIT), colour, shouldersFrontTexture);
 		// Back
-		mesh.addQuad(new Vector3f(14*unit, 24*unit, 6.5f*unit), new Vector3f(2*unit, 24*unit, 6.5f*unit), new Vector3f(2*unit, 21*unit, 6.5f*unit), new Vector3f(14*unit, 21*unit, 6.5f*unit), colour, shouldersFrontTexture);
+		mesh.addQuad(new Vector3f(14*UNIT, 24*UNIT, 6.5f*UNIT), new Vector3f(2*UNIT, 24*UNIT, 6.5f*UNIT), new Vector3f(2*UNIT, 21*UNIT, 6.5f*UNIT), new Vector3f(14*UNIT, 21*UNIT, 6.5f*UNIT), colour, shouldersFrontTexture);
 		// Top
-		mesh.addQuad(new Vector3f(2*unit, 24*unit, 6.5f*unit), new Vector3f(14*unit, 24*unit, 6.5f*unit), new Vector3f(14*unit, 24*unit, 9.5f*unit), new Vector3f(2*unit, 24*unit, 9.5f*unit), colour, shouldersFrontTexture);
+		mesh.addQuad(new Vector3f(2*UNIT, 24*UNIT, 6.5f*UNIT), new Vector3f(14*UNIT, 24*UNIT, 6.5f*UNIT), new Vector3f(14*UNIT, 24*UNIT, 9.5f*UNIT), new Vector3f(2*UNIT, 24*UNIT, 9.5f*UNIT), colour, shouldersFrontTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(2*unit, 24*unit, 6.5f*unit), new Vector3f(2*unit, 24*unit, 9.5f*unit), new Vector3f(2*unit, 21*unit, 9.5f*unit), new Vector3f(2*unit, 21*unit, 6.5f*unit), colour, shouldersSideTexture);
+		mesh.addQuad(new Vector3f(2*UNIT, 24*UNIT, 6.5f*UNIT), new Vector3f(2*UNIT, 24*UNIT, 9.5f*UNIT), new Vector3f(2*UNIT, 21*UNIT, 9.5f*UNIT), new Vector3f(2*UNIT, 21*UNIT, 6.5f*UNIT), colour, shouldersSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(14*unit, 24*unit, 9.5f*unit), new Vector3f(14*unit, 24*unit, 6.5f*unit), new Vector3f(14*unit, 21*unit, 6.5f*unit), new Vector3f(14*unit, 21*unit, 9.5f*unit), colour, shouldersSideTexture);
+		mesh.addQuad(new Vector3f(14*UNIT, 24*UNIT, 9.5f*UNIT), new Vector3f(14*UNIT, 24*UNIT, 6.5f*UNIT), new Vector3f(14*UNIT, 21*UNIT, 6.5f*UNIT), new Vector3f(14*UNIT, 21*UNIT, 9.5f*UNIT), colour, shouldersSideTexture);
 
 
                 // Neck/head
                 
 		// Front
-		mesh.addQuad(new Vector3f(7*unit, 30*unit, 9*unit), new Vector3f(9*unit, 30*unit, 9*unit), new Vector3f(9*unit, 24*unit, 9*unit), new Vector3f(7*unit, 24*unit, 9*unit), colour, neckSideTexture);
+		mesh.addQuad(new Vector3f(7*UNIT, 30*UNIT, 9*UNIT), new Vector3f(9*UNIT, 30*UNIT, 9*UNIT), new Vector3f(9*UNIT, 24*UNIT, 9*UNIT), new Vector3f(7*UNIT, 24*UNIT, 9*UNIT), colour, neckSideTexture);
 		// Back
-		mesh.addQuad(new Vector3f(9*unit, 30*unit, 7*unit), new Vector3f(7*unit, 30*unit, 7*unit), new Vector3f(7*unit, 24*unit, 7*unit), new Vector3f(9*unit, 24*unit, 7*unit), colour, neckSideTexture);
+		mesh.addQuad(new Vector3f(9*UNIT, 30*UNIT, 7*UNIT), new Vector3f(7*UNIT, 30*UNIT, 7*UNIT), new Vector3f(7*UNIT, 24*UNIT, 7*UNIT), new Vector3f(9*UNIT, 24*UNIT, 7*UNIT), colour, neckSideTexture);
 		// Top
-		mesh.addQuad(new Vector3f(7*unit, 30*unit, 7*unit), new Vector3f(9*unit, 30*unit, 7*unit), new Vector3f(9*unit, 30*unit, 9*unit), new Vector3f(7*unit, 30*unit, 9*unit), colour, neckTopTexture);
+		mesh.addQuad(new Vector3f(7*UNIT, 30*UNIT, 7*UNIT), new Vector3f(9*UNIT, 30*UNIT, 7*UNIT), new Vector3f(9*UNIT, 30*UNIT, 9*UNIT), new Vector3f(7*UNIT, 30*UNIT, 9*UNIT), colour, neckTopTexture);
 		// Left edge
-		mesh.addQuad(new Vector3f(7*unit, 30*unit, 7*unit), new Vector3f(7*unit, 30*unit, 9*unit), new Vector3f(7*unit, 24*unit, 9*unit), new Vector3f(7*unit, 24*unit, 7*unit), colour, neckSideTexture);
+		mesh.addQuad(new Vector3f(7*UNIT, 30*UNIT, 7*UNIT), new Vector3f(7*UNIT, 30*UNIT, 9*UNIT), new Vector3f(7*UNIT, 24*UNIT, 9*UNIT), new Vector3f(7*UNIT, 24*UNIT, 7*UNIT), colour, neckSideTexture);
 		// Right edge
-		mesh.addQuad(new Vector3f(9*unit, 30*unit, 9*unit), new Vector3f(9*unit, 30*unit, 7*unit), new Vector3f(9*unit, 24*unit, 7*unit), new Vector3f(9*unit, 24*unit, 9*unit), colour, neckSideTexture);
+		mesh.addQuad(new Vector3f(9*UNIT, 30*UNIT, 9*UNIT), new Vector3f(9*UNIT, 30*UNIT, 7*UNIT), new Vector3f(9*UNIT, 24*UNIT, 7*UNIT), new Vector3f(9*UNIT, 24*UNIT, 9*UNIT), colour, neckSideTexture);
 
                 
                 mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.AntiClockwise, angle);
         }
         
-        private void buildArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle, ArmorItem armor, byte layer, ArmorMeshBuilder meshBuilder) {
+        private void buildArmorMesh(int x, int y, int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry, ArmorStandEntity armorStand, Vector4f colour, ArmorItem armor, byte layer, ArmorMeshBuilder meshBuilder) {
+                final float angle = armorStand.getYaw();
+                                
                 String armorMaterial = armor.id.substring("minecraft:".length(), armor.id.indexOf('_'));
                 if (armorMaterial.equals("golden")) {
                         armorMaterial = "gold";
                 }
                 
-                SubTexture layer1Texture = texturePack.findTexture(String.format("assets/minecraft/textures/models/armor/%s_layer_%d.png", armorMaterial, layer));
-                SubTexture layer1OverlayTexture = texturePack.findTextureOrDefault(String.format("assets/minecraft/textures/models/armor/%s_layer_%d_overlay.png", armorMaterial, layer), null);
+                SubTexture layerTexture = texturePack.findTextureOrDefault(String.format("assets/minecraft/textures/models/armor/%s_layer_%d.png", armorMaterial, layer), null);
+                SubTexture overlayLayerTexture = texturePack.findTextureOrDefault(String.format("assets/minecraft/textures/models/armor/%s_layer_%d_overlay.png", armorMaterial, layer), null);
+                
+                if (layerTexture == null) {
+                        // Armor texture not found. Maybe it is some other item (e.g. mob head)
+                        // Try finding relevant item in block registry and add its geometry
+                        buildOtherItemMesh(x, y, z, world, registry, rawChunk, geometry, armorStand, colour, armor);
+                        return;
+                }
                 
                 if (armorMaterial.equals("leather")) {
-                        meshBuilder.build(x, y, z, geometry, colour, unit, angle, layer1OverlayTexture, 0);
+                        meshBuilder.build(x, y, z, geometry, colour, angle, overlayLayerTexture, 0);
                  
                         DisplayTag display = armor.getTag(DisplayTag.class);
                         colour = display == null
@@ -268,18 +277,71 @@ public class ArmorStand implements BlockType
                                 : new Vector4f(((display.color >> 16) & 255)/255f, ((display.color >> 8) & 255)/255f, (display.color & 255)/255f, 1);
                 }
 		
-                meshBuilder.build(x, y, z, geometry, colour, unit, angle, layer1Texture, -1);
+                meshBuilder.build(x, y, z, geometry, colour, angle, layerTexture, -1);
         }
         
-        private void buildFeetArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle, SubTexture texture, int offsetMultiplier) {
-            
+        private void buildOtherItemMesh(int x, int y, int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry, ArmorStandEntity armorStand, Vector4f colour, ArmorItem armor) {
+                BlockType blockType = registry.find(armor.id);
+                if (blockType != null) {
+                        if (blockType instanceof Skull) {
+                                // We do have a mob head, but there is no skull entity on these coordinates (there is armor stand instead).
+                                // Create entity and pass it to addEdgeGeometry via parameter so that the call does not fail with java.lang.NullPointerException
+                                // when trying to find and work with skull entity from rawChunk.
+
+                                int skullType = -1;
+                                switch (armor.id) {
+                                        case "minecraft:dragon_head":
+                                                skullType = 5;
+                                                break;
+                                        case "minecraft:piglin_head":
+                                                skullType = 6;
+                                                break;
+                                }
+                                
+                                // Convert rotation angle from degrees to 0..15 format used by skulls
+                                float rotation = armorStand.getYaw() - 180;
+                                while (rotation < 0) {
+                                    rotation += 360;
+                                }
+                                rotation = rotation / 360f * 16;
+
+                                // Use constructor that acceptas yOffset to elevate the skull to correct position on armor stand
+                                SkullEntity skullEntity = new SkullEntity(0, 0, 0, x, y, z, skullType, (int)Math.round(rotation), 24*UNIT);
+                                ((Skull)blockType).addEdgeGeometry(x, y, z, world, registry, rawChunk, geometry, skullEntity);
+                        } else if (blockType instanceof JackOLantern || armor.id.equals("minecraft:carved_pumpkin")) {
+                                SubTexture frontTexture = texturePack.findTexture("assets/minecraft/textures/block/carved_pumpkin.png");
+                                SubTexture sideTexture = texturePack.findTexture("assets/minecraft/textures/block/pumpkin_side.png");
+                                SubTexture topTexture = texturePack.findTexture("assets/minecraft/textures/block/pumpkin_top.png");
+                                
+                                SubMesh frontMesh = new SubMesh();
+                                SubMesh sideMesh = new SubMesh();
+                                SubMesh topMesh = new SubMesh();
+
+                                // Front
+                                frontMesh.addQuad(new Vector3f(4*UNIT, 32*UNIT, 12*UNIT), new Vector3f(12*UNIT, 32*UNIT, 12*UNIT), new Vector3f(12*UNIT, 24*UNIT, 12*UNIT), new Vector3f(4*UNIT, 24*UNIT, 12*UNIT), colour, frontTexture);
+                                // Back
+                                sideMesh.addQuad(new Vector3f(12*UNIT, 32*UNIT, 4*UNIT), new Vector3f(4*UNIT, 32*UNIT, 4*UNIT), new Vector3f(4*UNIT, 24*UNIT, 4*UNIT), new Vector3f(12*UNIT, 24*UNIT, 4*UNIT), colour, sideTexture);
+                                // Top
+                                topMesh.addQuad(new Vector3f(4*UNIT, 32*UNIT, 4*UNIT), new Vector3f(12*UNIT, 32*UNIT, 4*UNIT), new Vector3f(12*UNIT, 32*UNIT, 12*UNIT), new Vector3f(4*UNIT, 32*UNIT, 12*UNIT), colour, topTexture);
+                                // Left edge
+                                sideMesh.addQuad(new Vector3f(4*UNIT, 32*UNIT, 4*UNIT), new Vector3f(4*UNIT, 32*UNIT, 12*UNIT), new Vector3f(4*UNIT, 24*UNIT, 12*UNIT), new Vector3f(4*UNIT, 24*UNIT, 4*UNIT), colour, sideTexture);
+                                // Right edge
+                                sideMesh.addQuad(new Vector3f(12*UNIT, 32*UNIT, 12*UNIT), new Vector3f(12*UNIT, 32*UNIT, 4*UNIT), new Vector3f(12*UNIT, 24*UNIT, 4*UNIT), new Vector3f(12*UNIT, 24*UNIT, 12*UNIT), colour, sideTexture);
+
+                                frontMesh.pushTo(geometry.getMesh(frontTexture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.AntiClockwise, armorStand.getYaw());
+                                sideMesh.pushTo(geometry.getMesh(sideTexture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.AntiClockwise, armorStand.getYaw());
+                                topMesh.pushTo(geometry.getMesh(topTexture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.AntiClockwise, armorStand.getYaw());
+                        }
+                }
         }
         
-        private void buildLegsArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle, SubTexture texture, int offsetMultiplier) {
-            
+        private void buildFeetArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier) {
         }
         
-        private void buildChestArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle, SubTexture texture, int offsetMultiplier) {
+        private void buildLegsArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier) {
+        }
+        
+        private void buildChestArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier) {
                 final float widthTexel = 1.0f / 64.0f;
 		final float heightTexel = 1.0f / 32.0f;
     
@@ -289,86 +351,80 @@ public class ArmorStand implements BlockType
                 // Chest piece
                 
                 // Front
-		mesh.addDoubleSidedQuad(new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*20, texture.v0+heightTexel*20, texture.u0+widthTexel*28, texture.v0+heightTexel*32));
 		// Back
-		mesh.addDoubleSidedQuad(new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*32, texture.v0+heightTexel*20, texture.u0+widthTexel*40, texture.v0+heightTexel*32));
 		// Left edge
-		mesh.addDoubleSidedQuad(new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(3.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(3.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*16, texture.v0+heightTexel*20, texture.u0+widthTexel*20, texture.v0+heightTexel*32));
 		// Right edge
-		mesh.addDoubleSidedQuad(new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(12.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(12.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*28, texture.v0+heightTexel*20, texture.u0+widthTexel*32, texture.v0+heightTexel*32));
                 
                 
                 // Left pauldron (this one is "turned inside out" to produce mirror image of right pauldron)
 
                 // Front
-		mesh.addDoubleSidedQuad(new Vector3f(15.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit-offsetMultiplier*EPSILON), new Vector3f(10.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit-offsetMultiplier*EPSILON), new Vector3f(10.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit-offsetMultiplier*EPSILON), new Vector3f(15.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(15.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(15.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*44, texture.v0+heightTexel*20, texture.u0+widthTexel*48, texture.v0+heightTexel*32));
 		// Back
-		mesh.addDoubleSidedQuad(new Vector3f(10.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit+offsetMultiplier*EPSILON), new Vector3f(15.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit+offsetMultiplier*EPSILON), new Vector3f(15.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit+offsetMultiplier*EPSILON), new Vector3f(10.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(10.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(15.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(15.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*52, texture.v0+heightTexel*20, texture.u0+widthTexel*56, texture.v0+heightTexel*32));
 		// Top
-		mesh.addDoubleSidedQuad(
-                        new Vector3f(15.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON),
-                        new Vector3f(10.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON),
-                        new Vector3f(10.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON),
-                        new Vector3f(15.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON),
-                        colour,
+		mesh.addDoubleSidedQuad(new Vector3f(15.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(15.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*44, texture.v0+heightTexel*16, texture.u0+widthTexel*48, texture.v0+heightTexel*20));
 		// Left edge
-		mesh.addDoubleSidedQuad(new Vector3f(10.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(10.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(10.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(10.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(10.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(10.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*48, texture.v0+heightTexel*20, texture.u0+widthTexel*52, texture.v0+heightTexel*32));
 		// Right edge
-		mesh.addDoubleSidedQuad(new Vector3f(15.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(15.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(15.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(15.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(15.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(15.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(15.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(15.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*40, texture.v0+heightTexel*20, texture.u0+widthTexel*44, texture.v0+heightTexel*32));
 
 
                 // Right pauldron
 
                 // Front
-		mesh.addDoubleSidedQuad(new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*44, texture.v0+heightTexel*20, texture.u0+widthTexel*48, texture.v0+heightTexel*32));
 		// Back
-		mesh.addDoubleSidedQuad(new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*52, texture.v0+heightTexel*20, texture.u0+widthTexel*56, texture.v0+heightTexel*32));
 		// Top
-		mesh.addDoubleSidedQuad(new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*44, texture.v0+heightTexel*16, texture.u0+widthTexel*48, texture.v0+heightTexel*20));
 		// Left edge
-		mesh.addDoubleSidedQuad(new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(0.5f*unit-offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(0.5f*UNIT-offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*40, texture.v0+heightTexel*20, texture.u0+widthTexel*44, texture.v0+heightTexel*32));
 		// Right edge
-		mesh.addDoubleSidedQuad(new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 24.5f*unit+offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 5.5f*unit-offsetMultiplier*EPSILON), new Vector3f(5.5f*unit+offsetMultiplier*EPSILON, 11.5f*unit-offsetMultiplier*EPSILON, 10.5f*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 24.5f*UNIT+offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 5.5f*UNIT-offsetMultiplier*EPSILON), new Vector3f(5.5f*UNIT+offsetMultiplier*EPSILON, 11.5f*UNIT-offsetMultiplier*EPSILON, 10.5f*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*48, texture.v0+heightTexel*20, texture.u0+widthTexel*52, texture.v0+heightTexel*32));
                 
 		
                 mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.AlphaTest), x, y, z, Rotation.AntiClockwise, angle);
-
         }
         
-        private void buildHeadArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle, SubTexture texture, int offsetMultiplier) {
+        private void buildHeadArmorMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float angle, SubTexture texture, int offsetMultiplier) {
                 final float widthTexel = 1.0f / 64.0f;
 		final float heightTexel = 1.0f / 32.0f;
     
                 SubMesh mesh = new SubMesh();
 
                 // Front
-		mesh.addDoubleSidedQuad(new Vector3f(4*unit-offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), new Vector3f(4*unit-offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*8, texture.v0+heightTexel*8, texture.u0+widthTexel*16, texture.v0+heightTexel*16));
 		// Back
-		mesh.addDoubleSidedQuad(new Vector3f(12*unit+offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(4*unit-offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(4*unit-offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*24, texture.v0+heightTexel*8, texture.u0+widthTexel*32, texture.v0+heightTexel*16));
 		// Top
-		mesh.addDoubleSidedQuad(new Vector3f(4*unit-offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), new Vector3f(4*unit-offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*8, texture.v0+heightTexel*0, texture.u0+widthTexel*16, texture.v0+heightTexel*8));
 		// Left edge
-		mesh.addDoubleSidedQuad(new Vector3f(4*unit-offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(4*unit-offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), new Vector3f(4*unit-offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), new Vector3f(4*unit-offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), new Vector3f(4*UNIT-offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*8, texture.u0+widthTexel*8, texture.v0+heightTexel*16));
 		// Right edge
-		mesh.addDoubleSidedQuad(new Vector3f(12*unit+offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 32*unit+offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 4*unit-offsetMultiplier*EPSILON), new Vector3f(12*unit+offsetMultiplier*EPSILON, 24*unit-offsetMultiplier*EPSILON, 12*unit+offsetMultiplier*EPSILON), colour,
+		mesh.addDoubleSidedQuad(new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 32*UNIT+offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 4*UNIT-offsetMultiplier*EPSILON), new Vector3f(12*UNIT+offsetMultiplier*EPSILON, 24*UNIT-offsetMultiplier*EPSILON, 12*UNIT+offsetMultiplier*EPSILON), colour,
                         new SubTexture(texture.texture, texture.u0+widthTexel*16, texture.v0+heightTexel*8, texture.u0+widthTexel*24, texture.v0+heightTexel*16));
 		
                 mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.AlphaTest), x, y, z, Rotation.AntiClockwise, angle);

--- a/src/main/java/tectonicus/blockTypes/ArmorStand.java
+++ b/src/main/java/tectonicus/blockTypes/ArmorStand.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Tectonicus contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.blockTypes;
+
+import org.joml.Vector3f;
+import org.joml.Vector4f;
+import tectonicus.BlockContext;
+import tectonicus.BlockType;
+import tectonicus.BlockTypeRegistry;
+import tectonicus.rasteriser.SubMesh;
+import tectonicus.rasteriser.SubMesh.Rotation;
+import tectonicus.raw.ArmorStandEntity;
+import tectonicus.raw.RawChunk;
+import tectonicus.renderer.Geometry;
+import tectonicus.texture.SubTexture;
+import tectonicus.texture.TexturePack;
+
+public class ArmorStand implements BlockType
+{
+	private final String name;
+        
+        private final SubTexture texture;
+	
+        private final SubTexture baseTopTexture;
+        private final SubTexture baseSideTexture;
+
+        public ArmorStand(String name, TexturePack texturePack)
+	{
+		this.name = name;
+                
+                texture = texturePack.findTexture("assets/minecraft/textures/entity/armorstand/wood.png");
+                
+                final float widthTexel = 1.0f / 64.0f;
+		final float heightTexel = 1.0f / 64.0f;
+                
+		baseTopTexture = new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*32, texture.u0+widthTexel*24, texture.v0+heightTexel*44);
+		baseSideTexture = new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*44, texture.u0+widthTexel*24, texture.v0+heightTexel*45);
+	}
+	
+	@Override
+	public String getName()
+	{
+		return name;
+	}
+	
+	@Override
+	public boolean isSolid()
+	{
+		return false;
+	}
+	
+	@Override
+	public boolean isWater()
+	{
+		return false;
+	}
+	
+	
+	@Override
+	public void addInteriorGeometry(final int x, final int y, final int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry)
+	{
+                addEdgeGeometry(x, y, z, world, registry, rawChunk, geometry);
+	}
+	
+	@Override
+	public void addEdgeGeometry(int x, int y, int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry)
+	{
+                for (ArmorStandEntity entity : rawChunk.getArmorStands()) {
+                        x = entity.getLocalX();
+                        y = entity.getLocalY();
+                        z = entity.getLocalZ();
+                    
+                        final Vector4f colour = new Vector4f(1, 1, 1, 1);
+                        final float unit = 1.0f / 16.0f;
+
+                        buildBaseMesh(x, y, z, geometry, colour, unit);
+                }
+	}
+        
+        private void buildBaseMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit) {
+                SubMesh baseMesh = new SubMesh();
+		
+		// Front
+		baseMesh.addDoubleSidedQuad(new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), colour, baseSideTexture);
+		// Back
+		baseMesh.addDoubleSidedQuad(new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), colour, baseSideTexture);
+		// Top
+		baseMesh.addDoubleSidedQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(2*unit, 1*unit, 14*unit), colour, baseTopTexture);
+		// Left edge
+		baseMesh.addDoubleSidedQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 2*unit), colour, baseSideTexture);
+		// Right edge
+		baseMesh.addDoubleSidedQuad(new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 14*unit), colour, baseSideTexture);
+		
+                baseMesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.None, 0);
+        }
+}

--- a/src/main/java/tectonicus/blockTypes/ArmorStand.java
+++ b/src/main/java/tectonicus/blockTypes/ArmorStand.java
@@ -18,6 +18,7 @@ import tectonicus.rasteriser.SubMesh;
 import tectonicus.rasteriser.SubMesh.Rotation;
 import tectonicus.raw.ArmorItem;
 import tectonicus.raw.ArmorStandEntity;
+import tectonicus.raw.ArmorTrimTag;
 import tectonicus.raw.DisplayTag;
 import tectonicus.raw.RawChunk;
 import tectonicus.raw.SkullEntity;
@@ -260,6 +261,21 @@ public class ArmorStand implements BlockType
                 
                 SubTexture layerTexture = texturePack.findTextureOrDefault(String.format("assets/minecraft/textures/models/armor/%s_layer_%d.png", armorMaterial, layer), null);
                 SubTexture overlayLayerTexture = texturePack.findTextureOrDefault(String.format("assets/minecraft/textures/models/armor/%s_layer_%d_overlay.png", armorMaterial, layer), null);
+                
+                ArmorTrimTag armorTrim = armor.getTag(tectonicus.raw.ArmorTrimTag.class);
+                if (armorTrim != null) {
+                        final String pattern = armorTrim.pattern.substring("minecraft:".length());
+                        final String suffix = layer == 2 ? "_leggings" : "";
+                        final String material = armorTrim.material.substring("minecraft:".length());
+
+                        final String trimTextureFile = String.format("assets/minecraft/textures/trims/models/armor/%s%s.png", pattern, suffix);
+                        final String materialTextureFile = String.format("assets/minecraft/textures/trims/color_palettes/%s.png", material);
+                        final String paletteTextureFile = String.format("assets/minecraft/textures/trims/color_palettes/trim_palette.png", pattern, suffix);
+                        
+                        SubTexture trimTexture = texturePack.findPalettedTexture(trimTextureFile, materialTextureFile, paletteTextureFile);
+
+                        meshBuilder.build(x, y, z, geometry, colour, angle, trimTexture, 1);
+                }
                 
                 if (layerTexture == null) {
                         // Armor texture not found. Maybe it is some other item (e.g. mob head)

--- a/src/main/java/tectonicus/blockTypes/ArmorStand.java
+++ b/src/main/java/tectonicus/blockTypes/ArmorStand.java
@@ -97,8 +97,12 @@ public class ArmorStand implements BlockType
                         final float unit = 1.0f / 16.0f;
                         final float angle = entity.getYaw();
 
-                        buildBaseMesh(x, y, z, geometry, colour, unit);
-                        buildStandMesh(x, y, z, geometry, colour, unit, angle);
+                        if (!entity.getInvisible() && !entity.getNoBasePlate()) {
+                                buildBaseMesh(x, y, z, geometry, colour, unit);
+                        }
+                        if (!entity.getInvisible()) {
+                                buildStandMesh(x, y, z, geometry, colour, unit, angle);
+                        }
                 }
 	}
         

--- a/src/main/java/tectonicus/blockTypes/ArmorStand.java
+++ b/src/main/java/tectonicus/blockTypes/ArmorStand.java
@@ -30,6 +30,14 @@ public class ArmorStand implements BlockType
 	
         private final SubTexture baseTopTexture;
         private final SubTexture baseSideTexture;
+        private final SubTexture legSideTexture;
+        private final SubTexture hipsFrontTexture;
+        private final SubTexture hipsSideTexture;
+        private final SubTexture torsoSideTexture;
+        private final SubTexture shouldersFrontTexture;
+        private final SubTexture shouldersSideTexture;
+        private final SubTexture neckTopTexture;
+        private final SubTexture neckSideTexture;
 
         public ArmorStand(String name, TexturePack texturePack)
 	{
@@ -42,6 +50,14 @@ public class ArmorStand implements BlockType
                 
 		baseTopTexture = new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*32, texture.u0+widthTexel*24, texture.v0+heightTexel*44);
 		baseSideTexture = new SubTexture(texture.texture, texture.u0+widthTexel*12, texture.v0+heightTexel*44, texture.u0+widthTexel*24, texture.v0+heightTexel*45);
+		legSideTexture = new SubTexture(texture.texture, texture.u0+widthTexel*10, texture.v0+heightTexel*2, texture.u0+widthTexel*12, texture.v0+heightTexel*13);
+		hipsFrontTexture = new SubTexture(texture.texture, texture.u0+widthTexel*2, texture.v0+heightTexel*50, texture.u0+widthTexel*10, texture.v0+heightTexel*52);
+		hipsSideTexture = new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*50, texture.u0+widthTexel*2, texture.v0+heightTexel*52);
+                torsoSideTexture = new SubTexture(texture.texture, texture.u0+widthTexel*16, texture.v0+heightTexel*2, texture.u0+widthTexel*18, texture.v0+heightTexel*9);
+		shouldersFrontTexture = new SubTexture(texture.texture, texture.u0+widthTexel*3, texture.v0+heightTexel*29, texture.u0+widthTexel*15, texture.v0+heightTexel*32);
+		shouldersSideTexture = new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*29, texture.u0+widthTexel*3, texture.v0+heightTexel*32);
+                neckTopTexture = new SubTexture(texture.texture, texture.u0+widthTexel*2, texture.v0+heightTexel*0, texture.u0+widthTexel*4, texture.v0+heightTexel*2);
+                neckSideTexture = new SubTexture(texture.texture, texture.u0+widthTexel*0, texture.v0+heightTexel*2, texture.u0+widthTexel*2, texture.v0+heightTexel*8);
 	}
 	
 	@Override
@@ -79,25 +95,124 @@ public class ArmorStand implements BlockType
                     
                         final Vector4f colour = new Vector4f(1, 1, 1, 1);
                         final float unit = 1.0f / 16.0f;
+                        final float angle = entity.getYaw();
 
                         buildBaseMesh(x, y, z, geometry, colour, unit);
+                        buildStandMesh(x, y, z, geometry, colour, unit, angle);
                 }
 	}
         
         private void buildBaseMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit) {
-                SubMesh baseMesh = new SubMesh();
+                SubMesh mesh = new SubMesh();
 		
 		// Front
-		baseMesh.addDoubleSidedQuad(new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), colour, baseSideTexture);
 		// Back
-		baseMesh.addDoubleSidedQuad(new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), colour, baseSideTexture);
 		// Top
-		baseMesh.addDoubleSidedQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(2*unit, 1*unit, 14*unit), colour, baseTopTexture);
+		mesh.addQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(2*unit, 1*unit, 14*unit), colour, baseTopTexture);
 		// Left edge
-		baseMesh.addDoubleSidedQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 2*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(2*unit, 1*unit, 2*unit), new Vector3f(2*unit, 1*unit, 14*unit), new Vector3f(2*unit, 0*unit, 14*unit), new Vector3f(2*unit, 0*unit, 2*unit), colour, baseSideTexture);
 		// Right edge
-		baseMesh.addDoubleSidedQuad(new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 14*unit), colour, baseSideTexture);
+		mesh.addQuad(new Vector3f(14*unit, 1*unit, 14*unit), new Vector3f(14*unit, 1*unit, 2*unit), new Vector3f(14*unit, 0*unit, 2*unit), new Vector3f(14*unit, 0*unit, 14*unit), colour, baseSideTexture);
 		
-                baseMesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.None, 0);
+                mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.None, 0);
+        }
+
+        private void buildStandMesh(int x, int y, int z, Geometry geometry, Vector4f colour, float unit, float angle) {
+                SubMesh mesh = new SubMesh();
+
+
+                // Left leg
+                
+		// Front
+		mesh.addQuad(new Vector3f(5*unit, 12*unit, 9*unit), new Vector3f(7*unit, 12*unit, 9*unit), new Vector3f(7*unit, 1*unit, 9*unit), new Vector3f(5*unit, 1*unit, 9*unit), colour, legSideTexture);
+		// Back
+		mesh.addQuad(new Vector3f(7*unit, 12*unit, 7*unit), new Vector3f(5*unit, 12*unit, 7*unit), new Vector3f(5*unit, 1*unit, 7*unit), new Vector3f(7*unit, 1*unit, 7*unit), colour, legSideTexture);
+		// Left edge
+		mesh.addQuad(new Vector3f(5*unit, 12*unit, 7*unit), new Vector3f(5*unit, 12*unit, 9*unit), new Vector3f(5*unit, 1*unit, 9*unit), new Vector3f(5*unit, 1*unit, 7*unit), colour, legSideTexture);
+		// Right edge
+		mesh.addQuad(new Vector3f(7*unit, 12*unit, 9*unit), new Vector3f(7*unit, 12*unit, 7*unit), new Vector3f(7*unit, 1*unit, 7*unit), new Vector3f(7*unit, 1*unit, 9*unit), colour, legSideTexture);
+
+
+                // Right leg
+                
+		// Front
+		mesh.addQuad(new Vector3f(9*unit, 12*unit, 9*unit), new Vector3f(11*unit, 12*unit, 9*unit), new Vector3f(11*unit, 1*unit, 9*unit), new Vector3f(9*unit, 1*unit, 9*unit), colour, legSideTexture);
+		// Back
+		mesh.addQuad(new Vector3f(11*unit, 12*unit, 7*unit), new Vector3f(9*unit, 12*unit, 7*unit), new Vector3f(9*unit, 1*unit, 7*unit), new Vector3f(11*unit, 1*unit, 7*unit), colour, legSideTexture);
+		// Left edge
+		mesh.addQuad(new Vector3f(9*unit, 12*unit, 7*unit), new Vector3f(9*unit, 12*unit, 9*unit), new Vector3f(9*unit, 1*unit, 9*unit), new Vector3f(9*unit, 1*unit, 7*unit), colour, legSideTexture);
+		// Right edge
+		mesh.addQuad(new Vector3f(11*unit, 12*unit, 9*unit), new Vector3f(11*unit, 12*unit, 7*unit), new Vector3f(11*unit, 1*unit, 7*unit), new Vector3f(11*unit, 1*unit, 9*unit), colour, legSideTexture);
+
+                
+                // Hips
+                
+		// Front
+		mesh.addQuad(new Vector3f(4*unit, 14*unit, 9*unit), new Vector3f(12*unit, 14*unit, 9*unit), new Vector3f(12*unit, 12*unit, 9*unit), new Vector3f(4*unit, 12*unit, 9*unit), colour, hipsFrontTexture);
+		// Back
+		mesh.addQuad(new Vector3f(12*unit, 14*unit, 7*unit), new Vector3f(4*unit, 14*unit, 7*unit), new Vector3f(4*unit, 12*unit, 7*unit), new Vector3f(12*unit, 12*unit, 7*unit), colour, hipsFrontTexture);
+		// Top
+		mesh.addQuad(new Vector3f(4*unit, 14*unit, 7*unit), new Vector3f(12*unit, 14*unit, 7*unit), new Vector3f(12*unit, 14*unit, 9*unit), new Vector3f(4*unit, 14*unit, 9*unit), colour, hipsFrontTexture);
+		// Left edge
+		mesh.addQuad(new Vector3f(4*unit, 14*unit, 7*unit), new Vector3f(4*unit, 14*unit, 9*unit), new Vector3f(4*unit, 12*unit, 9*unit), new Vector3f(4*unit, 12*unit, 7*unit), colour, hipsSideTexture);
+		// Right edge
+		mesh.addQuad(new Vector3f(12*unit, 14*unit, 9*unit), new Vector3f(12*unit, 14*unit, 7*unit), new Vector3f(12*unit, 12*unit, 7*unit), new Vector3f(12*unit, 12*unit, 9*unit), colour, hipsSideTexture);
+
+
+                // Left part of torso
+                
+		// Front
+		mesh.addQuad(new Vector3f(5*unit, 21*unit, 9*unit), new Vector3f(7*unit, 21*unit, 9*unit), new Vector3f(7*unit, 14*unit, 9*unit), new Vector3f(5*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+		// Back
+		mesh.addQuad(new Vector3f(7*unit, 21*unit, 7*unit), new Vector3f(5*unit, 21*unit, 7*unit), new Vector3f(5*unit, 14*unit, 7*unit), new Vector3f(7*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		// Left edge
+		mesh.addQuad(new Vector3f(5*unit, 21*unit, 7*unit), new Vector3f(5*unit, 21*unit, 9*unit), new Vector3f(5*unit, 14*unit, 9*unit), new Vector3f(5*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		// Right edge
+		mesh.addQuad(new Vector3f(7*unit, 21*unit, 9*unit), new Vector3f(7*unit, 21*unit, 7*unit), new Vector3f(7*unit, 14*unit, 7*unit), new Vector3f(7*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+
+
+                // Right part of torso
+                
+		// Front
+		mesh.addQuad(new Vector3f(9*unit, 21*unit, 9*unit), new Vector3f(11*unit, 21*unit, 9*unit), new Vector3f(11*unit, 14*unit, 9*unit), new Vector3f(9*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+		// Back
+		mesh.addQuad(new Vector3f(11*unit, 21*unit, 7*unit), new Vector3f(9*unit, 21*unit, 7*unit), new Vector3f(9*unit, 14*unit, 7*unit), new Vector3f(11*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		// Left edge
+		mesh.addQuad(new Vector3f(9*unit, 21*unit, 7*unit), new Vector3f(9*unit, 21*unit, 9*unit), new Vector3f(9*unit, 14*unit, 9*unit), new Vector3f(9*unit, 14*unit, 7*unit), colour, torsoSideTexture);
+		// Right edge
+		mesh.addQuad(new Vector3f(11*unit, 21*unit, 9*unit), new Vector3f(11*unit, 21*unit, 7*unit), new Vector3f(11*unit, 14*unit, 7*unit), new Vector3f(11*unit, 14*unit, 9*unit), colour, torsoSideTexture);
+
+                
+                // Shoulders
+                
+		// Front
+		mesh.addQuad(new Vector3f(2*unit, 24*unit, 9.5f*unit), new Vector3f(14*unit, 24*unit, 9.5f*unit), new Vector3f(14*unit, 21*unit, 9.5f*unit), new Vector3f(2*unit, 21*unit, 9.5f*unit), colour, shouldersFrontTexture);
+		// Back
+		mesh.addQuad(new Vector3f(14*unit, 24*unit, 6.5f*unit), new Vector3f(2*unit, 24*unit, 6.5f*unit), new Vector3f(2*unit, 21*unit, 6.5f*unit), new Vector3f(14*unit, 21*unit, 6.5f*unit), colour, shouldersFrontTexture);
+		// Top
+		mesh.addQuad(new Vector3f(2*unit, 24*unit, 6.5f*unit), new Vector3f(14*unit, 24*unit, 6.5f*unit), new Vector3f(14*unit, 24*unit, 9.5f*unit), new Vector3f(2*unit, 24*unit, 9.5f*unit), colour, shouldersFrontTexture);
+		// Left edge
+		mesh.addQuad(new Vector3f(2*unit, 24*unit, 6.5f*unit), new Vector3f(2*unit, 24*unit, 9.5f*unit), new Vector3f(2*unit, 21*unit, 9.5f*unit), new Vector3f(2*unit, 21*unit, 6.5f*unit), colour, shouldersSideTexture);
+		// Right edge
+		mesh.addQuad(new Vector3f(14*unit, 24*unit, 9.5f*unit), new Vector3f(14*unit, 24*unit, 6.5f*unit), new Vector3f(14*unit, 21*unit, 6.5f*unit), new Vector3f(14*unit, 21*unit, 9.5f*unit), colour, shouldersSideTexture);
+
+
+                // Neck/head
+                
+		// Front
+		mesh.addQuad(new Vector3f(7*unit, 30*unit, 9*unit), new Vector3f(9*unit, 30*unit, 9*unit), new Vector3f(9*unit, 24*unit, 9*unit), new Vector3f(7*unit, 24*unit, 9*unit), colour, neckSideTexture);
+		// Back
+		mesh.addQuad(new Vector3f(9*unit, 30*unit, 7*unit), new Vector3f(7*unit, 30*unit, 7*unit), new Vector3f(7*unit, 24*unit, 7*unit), new Vector3f(9*unit, 24*unit, 7*unit), colour, neckSideTexture);
+		// Top
+		mesh.addQuad(new Vector3f(7*unit, 30*unit, 7*unit), new Vector3f(9*unit, 30*unit, 7*unit), new Vector3f(9*unit, 30*unit, 9*unit), new Vector3f(7*unit, 30*unit, 9*unit), colour, neckTopTexture);
+		// Left edge
+		mesh.addQuad(new Vector3f(7*unit, 30*unit, 7*unit), new Vector3f(7*unit, 30*unit, 9*unit), new Vector3f(7*unit, 24*unit, 9*unit), new Vector3f(7*unit, 24*unit, 7*unit), colour, neckSideTexture);
+		// Right edge
+		mesh.addQuad(new Vector3f(9*unit, 30*unit, 9*unit), new Vector3f(9*unit, 30*unit, 7*unit), new Vector3f(9*unit, 24*unit, 7*unit), new Vector3f(9*unit, 24*unit, 9*unit), colour, neckSideTexture);
+
+                
+                mesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.AntiClockwise, angle);
         }
 }

--- a/src/main/java/tectonicus/blockTypes/ChiseledBookshelf.java
+++ b/src/main/java/tectonicus/blockTypes/ChiseledBookshelf.java
@@ -159,7 +159,7 @@ public class ChiseledBookshelf implements BlockType
                 SubTexture texture = new SubTexture(occupiedTexture.texture, occupiedTexture.u0+widthTexel*wOffset, occupiedTexture.v0+heightTexel*hOffset, occupiedTexture.u0+widthTexel*(wOffset+4), occupiedTexture.v0+heightTexel*(hOffset+6));
                 
                 final float unit = 1.0f / 16.0f;
-                final float epsilon = 0.0051f / 16.0f; // So that book texture and front texture are not on the same plane
+                final float epsilon = 0.005f / 16.0f; // So that book texture and front texture are not on the same plane
                 
                 SubMesh subMesh = new SubMesh();
 		subMesh.addQuad(new Vector3f(wOffset*unit, (16-hOffset)*unit, 16*unit+epsilon),

--- a/src/main/java/tectonicus/blockTypes/ChiseledBookshelf.java
+++ b/src/main/java/tectonicus/blockTypes/ChiseledBookshelf.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Tectonicus contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.blockTypes;
+
+import tectonicus.BlockContext;
+import tectonicus.BlockType;
+import tectonicus.BlockTypeRegistry;
+import tectonicus.rasteriser.Mesh;
+import tectonicus.raw.BlockProperties;
+import tectonicus.raw.RawChunk;
+import tectonicus.renderer.Geometry;
+import tectonicus.texture.SubTexture;
+import tectonicus.texture.TexturePack;
+import tectonicus.util.Colour4f;
+
+public class ChiseledBookshelf implements BlockType
+{
+	private final String name;
+        
+        private final SubTexture emptyTexture;
+        private final SubTexture occupiedTexture;
+        private final SubTexture sideTexture;
+        private final SubTexture topTexture;
+	
+	public ChiseledBookshelf(String name, TexturePack texturePack)
+	{
+		this.name = name;
+                
+                emptyTexture = texturePack.findTexture("assets/minecraft/textures/block/chiseled_bookshelf_empty.png");
+                occupiedTexture = texturePack.findTexture("assets/minecraft/textures/block/chiseled_bookshelf_occupied.png");
+                sideTexture = texturePack.findTexture("assets/minecraft/textures/block/chiseled_bookshelf_side.png");
+                topTexture = texturePack.findTexture("assets/minecraft/textures/block/chiseled_bookshelf_top.png");
+	}
+	
+	@Override
+	public String getName()
+	{
+		return name;
+	}
+	
+	@Override
+	public boolean isSolid()
+	{
+		return true;
+	}
+	
+	@Override
+	public boolean isWater()
+	{
+		return false;
+	}
+	
+	
+	@Override
+	public void addInteriorGeometry(final int x, final int y, final int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry)
+	{
+                addEdgeGeometry(x, y, z, world, registry, rawChunk, geometry);
+	}
+	
+	@Override
+	public void addEdgeGeometry(int x, int y, int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry)
+	{
+                final Colour4f colour = new Colour4f(1, 1, 1, 1);
+            
+		Mesh topMesh = geometry.getMesh(topTexture.texture, Geometry.MeshType.Solid);
+		Mesh sideMesh = geometry.getMesh(sideTexture.texture, Geometry.MeshType.Solid);
+		Mesh emptyMesh = geometry.getMesh(emptyTexture.texture, Geometry.MeshType.Solid);
+                
+                SubTexture northTexture = sideTexture;
+                SubTexture southTexture = sideTexture;
+                SubTexture westTexture = sideTexture;
+                SubTexture eastTexture = sideTexture;
+                
+                Mesh northMesh = sideMesh;
+                Mesh southMesh = sideMesh;
+                Mesh westMesh = sideMesh;
+                Mesh eastMesh = sideMesh;
+                
+                final BlockProperties properties = rawChunk.getBlockState(x, y, z);
+                if (properties != null && properties.containsKey("facing")) {
+			final String facing = properties.get("facing");
+			switch (facing) {
+				case "north":
+                                        eastTexture = emptyTexture;
+                                        eastMesh = emptyMesh;                                        
+					break;
+				case "south":
+                                        westTexture = emptyTexture;
+                                        westMesh = emptyMesh;                                        
+					break;
+				case "west":
+                                        northTexture = emptyTexture;
+                                        northMesh = emptyMesh;                                        
+					break;
+				case "east":
+                                        southTexture = emptyTexture;
+                                        southMesh = emptyMesh;                                        
+					break;
+			}
+		}
+
+                BlockUtil.addTop(world, rawChunk, topMesh, x, y, z, colour, topTexture, registry);
+		BlockUtil.addBottom(world, rawChunk, topMesh, x, y, z, colour, topTexture, registry);
+		
+		BlockUtil.addNorth(world, rawChunk, northMesh, x, y, z, colour, northTexture, registry);
+		BlockUtil.addSouth(world, rawChunk, southMesh, x, y, z, colour, southTexture, registry);
+		BlockUtil.addEast(world, rawChunk, eastMesh, x, y, z, colour, westTexture, registry);
+		BlockUtil.addWest(world, rawChunk, westMesh, x, y, z, colour, eastTexture, registry);
+	}
+}

--- a/src/main/java/tectonicus/blockTypes/ChiseledBookshelf.java
+++ b/src/main/java/tectonicus/blockTypes/ChiseledBookshelf.java
@@ -9,10 +9,14 @@
 
 package tectonicus.blockTypes;
 
+import org.joml.Vector3f;
+import org.joml.Vector4f;
 import tectonicus.BlockContext;
 import tectonicus.BlockType;
 import tectonicus.BlockTypeRegistry;
 import tectonicus.rasteriser.Mesh;
+import tectonicus.rasteriser.SubMesh;
+import tectonicus.rasteriser.SubMesh.Rotation;
 import tectonicus.raw.BlockProperties;
 import tectonicus.raw.RawChunk;
 import tectonicus.renderer.Geometry;
@@ -113,5 +117,81 @@ public class ChiseledBookshelf implements BlockType
 		BlockUtil.addSouth(world, rawChunk, southMesh, x, y, z, colour, southTexture, registry);
 		BlockUtil.addEast(world, rawChunk, eastMesh, x, y, z, colour, westTexture, registry);
 		BlockUtil.addWest(world, rawChunk, westMesh, x, y, z, colour, eastTexture, registry);
+                
+                if (isSlotOccupied(0, properties)) {
+                        drawOccupiedSlot(x, y, z, geometry, properties, 1, 1);
+                }
+                if (isSlotOccupied(1, properties)) {
+                        drawOccupiedSlot(x, y, z, geometry, properties, 6, 1);
+                }
+                if (isSlotOccupied(2, properties)) {
+                        drawOccupiedSlot(x, y, z, geometry, properties, 11, 1);
+                }
+                if (isSlotOccupied(3, properties)) {
+                        drawOccupiedSlot(x, y, z, geometry, properties, 1, 9);
+                }
+                if (isSlotOccupied(4, properties)) {
+                        drawOccupiedSlot(x, y, z, geometry, properties, 6, 9);
+                }
+                if (isSlotOccupied(5, properties)) {
+                        drawOccupiedSlot(x, y, z, geometry, properties, 11, 9);
+                }
 	}
+        
+        private static Boolean isSlotOccupied(int slotIndex, BlockProperties properties) {
+                final String propertyName = String.format("slot_%d_occupied", slotIndex);
+            
+                if (properties != null && properties.containsKey(propertyName)) {
+			final String slotOccupied = properties.get(propertyName);
+                        return "true".equals(slotOccupied);
+                }
+
+                return false;
+        }
+        
+        private void drawOccupiedSlot(int x, int y, int z, Geometry geometry, BlockProperties properties, int wOffset, int hOffset) {
+                Vector4f white = new Vector4f(1, 1, 1, 1);
+                float angle = getRotationDataFromFacing(properties);
+                
+                final float widthTexel = 1.0f / 16.0f;
+		final float heightTexel = 1.0f / 16.0f;
+
+                SubTexture texture = new SubTexture(occupiedTexture.texture, occupiedTexture.u0+widthTexel*wOffset, occupiedTexture.v0+heightTexel*hOffset, occupiedTexture.u0+widthTexel*(wOffset+4), occupiedTexture.v0+heightTexel*(hOffset+6));
+                
+                final float unit = 1.0f / 16.0f;
+                final float epsilon = 0.0051f / 16.0f; // So that book texture and front texture are not on the same plane
+                
+                SubMesh subMesh = new SubMesh();
+		subMesh.addQuad(new Vector3f(wOffset*unit, (16-hOffset)*unit, 16*unit+epsilon),
+                                new Vector3f((wOffset+4)*unit, (16-hOffset)*unit, 16*unit+epsilon),
+                                new Vector3f((wOffset+4)*unit, (16-hOffset-6)*unit, 16*unit+epsilon),
+                                new Vector3f(wOffset*unit, (16-hOffset-6)*unit, 16*unit+epsilon),
+                                white, texture);
+		subMesh.pushTo(geometry.getMesh(texture.texture, Geometry.MeshType.Solid), x, y, z, Rotation.AntiClockwise, angle);
+        }
+        
+        private static float getRotationDataFromFacing(BlockProperties properties) {
+                int data = 0;
+		
+                if (properties != null && properties.containsKey("facing")) {
+			final String facing = properties.get("facing");
+			switch (facing) {
+				case "north":
+					data = 180;
+					break;
+				case "south":
+					data = 0;
+					break;
+				case "west":
+					data = 90;
+					break;
+				case "east":
+					data = 270;
+					break;
+				default:
+			}
+		}
+                
+                return data;
+        }
 }

--- a/src/main/java/tectonicus/blockTypes/DecoratedPot.java
+++ b/src/main/java/tectonicus/blockTypes/DecoratedPot.java
@@ -86,7 +86,7 @@ public class DecoratedPot implements BlockType
 	@Override
 	public boolean isSolid()
 	{
-		return true;
+		return false;
 	}
 	
 	@Override

--- a/src/main/java/tectonicus/blockTypes/DecoratedPot.java
+++ b/src/main/java/tectonicus/blockTypes/DecoratedPot.java
@@ -23,6 +23,7 @@ import tectonicus.raw.DecoratedPotEntity;
 import tectonicus.raw.RawChunk;
 import tectonicus.renderer.Geometry;
 import tectonicus.texture.SubTexture;
+import tectonicus.texture.TexturePack;
 
 public class DecoratedPot implements BlockType
 {
@@ -35,12 +36,38 @@ public class DecoratedPot implements BlockType
         private final SubTexture neckTopTexture;
         private final SubTexture neckSideTexture;
 
-	public DecoratedPot(String name, SubTexture baseTexture, HashMap<String, SubTexture> textures)
+	public DecoratedPot(String name, TexturePack texturePack)
 	{
 		this.name = name;
-
-                this.baseTexture = baseTexture;
-                this.textures = textures;
+                
+                baseTexture = texturePack.findTexture("assets/minecraft/textures/entity/decorated_pot/decorated_pot_base.png");
+                
+                textures = new HashMap<>();
+                textures.put("minecraft:brick", texturePack.findTexture("assets/minecraft/textures/entity/decorated_pot/decorated_pot_side.png"));
+                for (var pattern : new String[] {
+                    "angler",
+                    "archer",
+                    "arms_up",
+                    "blade",
+                    "brewer",
+                    "burn",
+                    "danger",
+                    "explorer",
+                    "friend",
+                    "heart",
+                    "heartbreak",
+                    "howl",
+                    "miner",
+                    "mourner",
+                    "plenty",
+                    "prize",
+                    "sheaf",
+                    "shelter",
+                    "skull",
+                    "snort"
+                }) {
+                        textures.put("minecraft:"+pattern+"_pottery_sherd", texturePack.findTexture("assets/minecraft/textures/entity/decorated_pot/"+pattern+"_pottery_pattern.png"));
+                }
                 
                 final float widthTexel = 1.0f / 32.0f;
                 final float heightTexel = 1.0f / 32.0f;

--- a/src/main/java/tectonicus/blockTypes/PaintingNew.java
+++ b/src/main/java/tectonicus/blockTypes/PaintingNew.java
@@ -109,6 +109,10 @@ public class PaintingNew implements BlockType
 				case "skullandroses":
 				case "skull_and_roses":
 				case "wither":
+				case "earth":
+				case "fire":
+				case "water":
+				case "wind":
 					numTilesX = numTilesY = 2;
 					dim1 = dim2 = numTilesX * 16;
 					break;

--- a/src/main/java/tectonicus/blockTypes/Skull.java
+++ b/src/main/java/tectonicus/blockTypes/Skull.java
@@ -85,8 +85,15 @@ public class Skull implements BlockType
 	}
 
 	@Override
-	public void addEdgeGeometry(int x, int y, int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry) 
-	{				
+	public void addEdgeGeometry(int x, int y, int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry)
+        {
+		String xyz = "x" + x + "y" + y + "z" + z;
+                SkullEntity skullEntity = rawChunk.getSkulls().get(xyz);
+                addEdgeGeometry(x, y, z, world, registry, rawChunk, geometry, skullEntity);
+        }
+
+        public void addEdgeGeometry(int x, int y, int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry, SkullEntity entity) 
+        {				
 		SubMesh subMesh = new SubMesh();
 
 		//1.13+
@@ -98,8 +105,6 @@ public class Skull implements BlockType
 			facing = properties.get("facing");
 			rotationString = properties.get("rotation");
 		}
-		String xyz = "x" + x + "y" + y + "z" + z;
-		SkullEntity entity = rawChunk.getSkulls().get(xyz);
 		int rotationValue;
 		if (rotationString != null) {
 			rotationValue = Integer.parseInt(properties.get("rotation"));
@@ -137,7 +142,7 @@ public class Skull implements BlockType
 			currentTexture = dtexture;
 		
 		final boolean dragonHead = blockId == 5 || blockName.equals("minecraft:dragon_head") || blockName.equals("minecraft:dragon_wall_head");
-                final boolean piglinHead = blockName.equals("minecraft:piglin_head") || blockName.equals("minecraft:piglin_wall_head");
+                final boolean piglinHead = blockId == 6 || blockName.equals("minecraft:piglin_head") || blockName.equals("minecraft:piglin_wall_head");
 		
 		Player player = new Player(entity.getName(), entity.getUUID(), entity.getSkinURL());
 		if(!player.getSkinURL().equals(""))
@@ -452,8 +457,8 @@ public class Skull implements BlockType
 		}
 
 		if(data > 1 || facing != null)
-			subMesh.pushTo(geometry.getMesh(currentTexture.texture, Geometry.MeshType.Solid), xOffset, yOffset+offSet*4, zOffset, rotation, angle);
+			subMesh.pushTo(geometry.getMesh(currentTexture.texture, Geometry.MeshType.Solid), xOffset, yOffset+offSet*4+entity.getYOffset(), zOffset, rotation, angle);
 		else
-			subMesh.pushTo(geometry.getMesh(currentTexture.texture, Geometry.MeshType.Solid), x, y, z, rotation, angle);			
+			subMesh.pushTo(geometry.getMesh(currentTexture.texture, Geometry.MeshType.Solid), x, y+entity.getYOffset(), z, rotation, angle);			
 	}
 }

--- a/src/main/java/tectonicus/chunk/Chunk.java
+++ b/src/main/java/tectonicus/chunk/Chunk.java
@@ -205,6 +205,11 @@ public class Chunk
 		type = registry.find(-2, 0);
 		if (type != null)
 			type.addEdgeGeometry(0, 0, 0, world, registry, rawChunk, geometry);
+                
+                // Create armor stand geometry
+		type = registry.find(-3, 0);
+		if (type != null)
+			type.addEdgeGeometry(0, 0, 0, world, registry, rawChunk, geometry);
 		
 		/*
 		for (int y=0; y<RawChunk.HEIGHT; y++)

--- a/src/main/java/tectonicus/raw/ArmorItem.java
+++ b/src/main/java/tectonicus/raw/ArmorItem.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Tectonicus other contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.raw;
+
+public class ArmorItem extends ItemBase
+{
+	public ArmorItem(final String id, ArmorTrimTag armorTrim, DisplayTag display)
+	{
+                super(id, 0, 0, 0, null);
+
+                if (armorTrim != null) {
+                        tag.add(armorTrim);
+                }
+                if (display != null) {
+                        tag.add(display);
+                }
+	}
+}

--- a/src/main/java/tectonicus/raw/ArmorStandEntity.java
+++ b/src/main/java/tectonicus/raw/ArmorStandEntity.java
@@ -11,8 +11,14 @@ package tectonicus.raw;
 
 public class ArmorStandEntity extends BlockEntity
 {
-	public ArmorStandEntity(int x, int y, int z, int localX, int localY, int localZ)
+        private final float yaw;
+    
+	public ArmorStandEntity(int x, int y, int z, int localX, int localY, int localZ, float yaw)
 	{
 		super(x, y, z, localX, localY, localZ);
+                
+                this.yaw = yaw;
 	}
+        
+        public float getYaw() { return yaw; }
 }

--- a/src/main/java/tectonicus/raw/ArmorStandEntity.java
+++ b/src/main/java/tectonicus/raw/ArmorStandEntity.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024, Tectonicus contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.raw;
+
+public class ArmorStandEntity extends BlockEntity
+{
+	public ArmorStandEntity(int x, int y, int z, int localX, int localY, int localZ)
+	{
+		super(x, y, z, localX, localY, localZ);
+	}
+}

--- a/src/main/java/tectonicus/raw/ArmorStandEntity.java
+++ b/src/main/java/tectonicus/raw/ArmorStandEntity.java
@@ -14,17 +14,33 @@ public class ArmorStandEntity extends BlockEntity
         private final float yaw;
         private final boolean invisible;
         private final boolean noBasePlate;
+        
+        private final ArmorItem feetArmor;
+        private final ArmorItem legsArmor;
+        private final ArmorItem chestArmor;
+        private final ArmorItem headArmor;
     
-	public ArmorStandEntity(int x, int y, int z, int localX, int localY, int localZ, float yaw, boolean invisible, boolean noBasePlate)
+	public ArmorStandEntity(int x, int y, int z, int localX, int localY, int localZ, float yaw, boolean invisible, boolean noBasePlate,
+                                ArmorItem feetArmor, ArmorItem legsArmor, ArmorItem chestArmor, ArmorItem headArmor)
 	{
 		super(x, y, z, localX, localY, localZ);
                 
                 this.yaw = yaw;
                 this.invisible = invisible;
                 this.noBasePlate = noBasePlate;
+                
+                this.feetArmor = feetArmor;
+                this.legsArmor = legsArmor;
+                this.chestArmor = chestArmor;
+                this.headArmor = headArmor;
 	}
         
         public float getYaw() { return yaw; }
         public boolean getInvisible() { return invisible; }
         public boolean getNoBasePlate() { return noBasePlate; }
+        
+        public ArmorItem getFeetArmor() { return feetArmor; }
+        public ArmorItem getLegsArmor() { return legsArmor; }
+        public ArmorItem getChestArmor() { return chestArmor; }
+        public ArmorItem getHeadArmor() { return headArmor; }
 }

--- a/src/main/java/tectonicus/raw/ArmorStandEntity.java
+++ b/src/main/java/tectonicus/raw/ArmorStandEntity.java
@@ -12,13 +12,19 @@ package tectonicus.raw;
 public class ArmorStandEntity extends BlockEntity
 {
         private final float yaw;
+        private final boolean invisible;
+        private final boolean noBasePlate;
     
-	public ArmorStandEntity(int x, int y, int z, int localX, int localY, int localZ, float yaw)
+	public ArmorStandEntity(int x, int y, int z, int localX, int localY, int localZ, float yaw, boolean invisible, boolean noBasePlate)
 	{
 		super(x, y, z, localX, localY, localZ);
                 
                 this.yaw = yaw;
+                this.invisible = invisible;
+                this.noBasePlate = noBasePlate;
 	}
         
         public float getYaw() { return yaw; }
+        public boolean getInvisible() { return invisible; }
+        public boolean getNoBasePlate() { return noBasePlate; }
 }

--- a/src/main/java/tectonicus/raw/ArmorTrimTag.java
+++ b/src/main/java/tectonicus/raw/ArmorTrimTag.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, Tectonicus and other contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.raw;
+
+public class ArmorTrimTag
+{
+        public String material;
+        public String pattern;
+        
+        public ArmorTrimTag(String material, String pattern) {
+                this.material = material;
+                this.pattern = pattern;
+        }
+}

--- a/src/main/java/tectonicus/raw/DisplayTag.java
+++ b/src/main/java/tectonicus/raw/DisplayTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tectonicus contributors.  All rights reserved.
+ * Copyright (c) 2024, Tectonicus and other contributors.  All rights reserved.
  *
  * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
  * the top-level directory of this distribution.  The full list of project contributors is contained
@@ -9,12 +9,11 @@
 
 package tectonicus.raw;
 
-import java.util.List;
-
-public class Item extends ItemBase
+public class DisplayTag
 {
-	public Item(final String id, final int damage, final int count, final int slot, final List<Object> tag)
-	{
-		super(id, damage, count, slot, tag);
-	}
+        public int color;
+        
+        public DisplayTag(int color) {
+                this.color = color;
+        }
 }

--- a/src/main/java/tectonicus/raw/ItemBase.java
+++ b/src/main/java/tectonicus/raw/ItemBase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Tectonicus other contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.raw;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class ItemBase
+{
+	public String id;
+	public int damage;
+	public int count;
+	public int slot;
+        public List<Object> tag;
+	
+	public ItemBase(final String id, final int damage, final int count, final int slot, List<Object> tag)
+	{
+		this.id = id;
+		this.damage = damage;
+		this.count = count;
+		this.slot = slot;
+                this.tag = tag;
+                
+                if (this.tag == null) {
+                        this.tag = new ArrayList<>();
+                }
+	}
+        
+        @SuppressWarnings("unchecked")
+        public <T> T getTag(Class<T> clazz) {
+                T result = null;
+                for (Object o : tag) {
+                        if (clazz.isInstance(o)) {
+                                result = (T)o;
+                        }
+                }
+                return result;
+        }
+}

--- a/src/main/java/tectonicus/raw/Player.java
+++ b/src/main/java/tectonicus/raw/Player.java
@@ -177,14 +177,14 @@ public class Player
 				{
 					CompoundTag itemTag = (CompoundTag)t;
 
-					ShortTag idTag = NbtUtil.getChild(itemTag, "id", ShortTag.class);
+					StringTag idTag = NbtUtil.getChild(itemTag, "id", StringTag.class);
 					ShortTag damageTag = NbtUtil.getChild(itemTag, "Damage", ShortTag.class);
 					ByteTag countTag = NbtUtil.getChild(itemTag, "Count", ByteTag.class);
 					ByteTag slotTag = NbtUtil.getChild(itemTag, "Slot", ByteTag.class);
 
 					if (idTag != null && damageTag != null && countTag != null && slotTag != null)
 					{
-						inventory.add( new Item(idTag.getValue(), damageTag.getValue(), countTag.getValue(), slotTag.getValue()) );
+						inventory.add( new Item(idTag.getValue(), damageTag.getValue(), countTag.getValue(), slotTag.getValue(), null) );
 					}
 				}
 			}

--- a/src/main/java/tectonicus/raw/RawChunk.java
+++ b/src/main/java/tectonicus/raw/RawChunk.java
@@ -308,8 +308,10 @@ public class RawChunk {
 				} else if (armorStand) {
                                         ListTag posTag = NbtUtil.getChild(entity, "Pos", ListTag.class);
                                         ListTag rotationTag = NbtUtil.getChild(entity, "Rotation", ListTag.class);
+                                        ByteTag invisibleTag = NbtUtil.getChild(entity, "Invisible", ByteTag.class);
+                                        ByteTag noBasePlateTag = NbtUtil.getChild(entity, "NoBasePlate", ByteTag.class);
                                         
-                                        if (posTag != null && rotationTag != null) {
+                                        if (posTag != null && rotationTag != null && invisibleTag != null && noBasePlateTag != null) {
                                                 List<Tag> pos = posTag.getValue();
 
                                                 int x = (int)Math.round(Math.floor((double)pos.get(0).getValue()));
@@ -328,7 +330,10 @@ public class RawChunk {
                                                 List<Tag> rotation = rotationTag.getValue();
                                                 float yaw = (float)rotation.get(0).getValue();
                                                 
-                                                armorStands.add(new ArmorStandEntity(x, y, z, localX, localY, localZ, yaw));
+                                                boolean invisible = invisibleTag.getValue() == 1;
+                                                boolean noBasePlate = noBasePlateTag.getValue() == 1;
+                                                
+                                                armorStands.add(new ArmorStandEntity(x, y, z, localX, localY, localZ, yaw, invisible, noBasePlate));
                                         }                                        
                                 }
 			}

--- a/src/main/java/tectonicus/raw/RawChunk.java
+++ b/src/main/java/tectonicus/raw/RawChunk.java
@@ -333,7 +333,55 @@ public class RawChunk {
                                                 boolean invisible = invisibleTag.getValue() == 1;
                                                 boolean noBasePlate = noBasePlateTag.getValue() == 1;
                                                 
-                                                armorStands.add(new ArmorStandEntity(x, y, z, localX, localY, localZ, yaw, invisible, noBasePlate));
+                                                ArmorItem feetArmor = null;
+                                                ArmorItem legsArmor = null;
+                                                ArmorItem chestArmor = null;
+                                                ArmorItem headArmor = null;
+                                                
+                                                ListTag armorItemsTag = NbtUtil.getChild(entity, "ArmorItems", ListTag.class);
+                                                if (armorItemsTag != null) {
+                                                        Function<CompoundTag, ArmorItem> parseArmorItem = (armorItemTag) -> {
+                                                                StringTag armorIdTag = NbtUtil.getChild(armorItemTag, "id", StringTag.class);
+                                                                
+                                                                if (armorIdTag != null) {
+                                                                        ArmorTrimTag armorTrim = null;
+                                                                        DisplayTag display = null;
+                                                                        
+                                                                        
+                                                                        CompoundTag tagTag = NbtUtil.getChild(armorItemTag, "tag", CompoundTag.class);
+                                                                        if (tagTag != null) {
+                                                                                CompoundTag trimTag = NbtUtil.getChild(tagTag, "Trim", CompoundTag.class);
+                                                                                if (trimTag != null) {
+                                                                                        StringTag materialTag = NbtUtil.getChild(trimTag, "material", StringTag.class);
+                                                                                        StringTag patternTag = NbtUtil.getChild(trimTag, "pattern", StringTag.class);
+                                                                                        if (materialTag != null && patternTag != null) {
+                                                                                                armorTrim = new ArmorTrimTag(materialTag.getValue(), patternTag.getValue());
+                                                                                        }
+                                                                                }
+                                                                                
+                                                                                CompoundTag displayTag = NbtUtil.getChild(tagTag, "display", CompoundTag.class);
+                                                                                if (displayTag != null) {
+                                                                                        IntTag colorTag = NbtUtil.getChild(displayTag, "color", IntTag.class);
+                                                                                        if (colorTag != null) {
+                                                                                                display = new DisplayTag(colorTag.getValue());
+                                                                                        }
+                                                                                }
+                                                                        }
+                                                                        
+                                                                        return new ArmorItem(armorIdTag.getValue(), armorTrim, display);
+                                                                }
+                                                                
+                                                                return null;
+                                                        };
+                                                        
+                                                        feetArmor = parseArmorItem.apply(NbtUtil.getChild(armorItemsTag, 0, CompoundTag.class));
+                                                        legsArmor = parseArmorItem.apply(NbtUtil.getChild(armorItemsTag, 1, CompoundTag.class));
+                                                        chestArmor = parseArmorItem.apply(NbtUtil.getChild(armorItemsTag, 2, CompoundTag.class));
+                                                        headArmor = parseArmorItem.apply(NbtUtil.getChild(armorItemsTag, 3, CompoundTag.class));
+                                                }
+                                                
+                                                armorStands.add(new ArmorStandEntity(x, y, z, localX, localY, localZ,
+                                                        yaw, invisible, noBasePlate, feetArmor, legsArmor, chestArmor, headArmor));
                                         }                                        
                                 }
 			}

--- a/src/main/java/tectonicus/raw/RawChunk.java
+++ b/src/main/java/tectonicus/raw/RawChunk.java
@@ -307,8 +307,9 @@ public class RawChunk {
 					}
 				} else if (armorStand) {
                                         ListTag posTag = NbtUtil.getChild(entity, "Pos", ListTag.class);
+                                        ListTag rotationTag = NbtUtil.getChild(entity, "Rotation", ListTag.class);
                                         
-                                        if (posTag != null) {
+                                        if (posTag != null && rotationTag != null) {
                                                 List<Tag> pos = posTag.getValue();
 
                                                 int x = (int)Math.round(Math.floor((double)pos.get(0).getValue()));
@@ -323,8 +324,11 @@ public class RawChunk {
                                                         localY = y;
                                                 }
                                                 final int localZ = z - (chunkZ * DEPTH);
-
-                                                armorStands.add(new ArmorStandEntity(x, y, z, localX, localY, localZ));
+                                                
+                                                List<Tag> rotation = rotationTag.getValue();
+                                                float yaw = (float)rotation.get(0).getValue();
+                                                
+                                                armorStands.add(new ArmorStandEntity(x, y, z, localX, localY, localZ, yaw));
                                         }                                        
                                 }
 			}

--- a/src/main/java/tectonicus/raw/SkullEntity.java
+++ b/src/main/java/tectonicus/raw/SkullEntity.java
@@ -14,6 +14,9 @@ import lombok.Getter;
 @Getter
 public class SkullEntity extends BlockEntity
 {
+        // Used to position the skull when on armor stand
+        private float yOffset = 0;
+        
 	private final int skullType;
 	private final int rotation;
 	private final String name;
@@ -23,6 +26,12 @@ public class SkullEntity extends BlockEntity
 	public SkullEntity(int x, int y, int z, int localX, int localY, int localZ, String name, String uuid, String skinURL)
 	{
 		this(x, y, z, localX, localY, localZ, -1, -1, name, uuid, skinURL);
+	}
+        
+        public SkullEntity(int x, int y, int z, int localX, int localY, int localZ, int skullType, int rotation, float yOffset)
+	{
+		this(x, y, z, localX, localY, localZ, skullType, rotation, "", "", "");
+                this.yOffset = yOffset;
 	}
 
 	public SkullEntity(int x, int y, int z, int localX, int localY, int localZ, int skullType, int rotation, String name, String uuid, String skinURL)

--- a/src/main/java/tectonicus/texture/PackTexture.java
+++ b/src/main/java/tectonicus/texture/PackTexture.java
@@ -28,6 +28,7 @@ public class PackTexture
 {
 	private final Rasteriser rasteriser;
 	
+        @Getter
 	private final String path;
 
 	@Getter

--- a/src/main/java/tectonicus/texture/TexturePack.java
+++ b/src/main/java/tectonicus/texture/TexturePack.java
@@ -325,6 +325,26 @@ public class TexturePack
 
 		return result;
 	}
+        
+        public SubTexture findPalettedTexture(String texturePath, String palettePath, String keyPalettePath) {
+		if (texturePath == null || palettePath == null || keyPalettePath == null)
+			return null;
+
+		TextureRequest textureRequest = parseRequest(texturePath);
+		TextureRequest paletteRequest = parseRequest(palettePath);
+		TextureRequest keyPaletteRequest = parseRequest(keyPalettePath);
+
+		PackTexture texture = findTexture(textureRequest, true); // find existing PackTexture or load
+		PackTexture palette = findTexture(paletteRequest, true); // find existing PackTexture or load
+		PackTexture keyPalette = findTexture(keyPaletteRequest, true); // find existing PackTexture or load
+                
+                if (texture != null && palette != null && keyPalette != null) {
+                        PackTexture palettedTexture = applyPalette(texture, palette, keyPalette); // find existing PackTexture or apply palette and load
+                        return palettedTexture.getFullTexture();
+                }
+
+		return null;
+        }
 
 	public SubTexture findTexture(String texturePath) {
 		if (texturePath == null)
@@ -362,7 +382,7 @@ public class TexturePack
 
 		return result;
 	}
-	
+        
 	private TextureRequest parseRequest(String texturePath)
 	{
 		// texture path could be:
@@ -422,6 +442,41 @@ public class TexturePack
 
 		return pathPrefix;
 	}
+        
+        private PackTexture applyPalette(PackTexture texture, PackTexture palette, PackTexture keyPalette) {
+                String path = texture.getPath()+palette.getPath()+keyPalette.getPath();
+                PackTexture tex = loadedPackTextures.get(path);
+                
+                if (tex == null) {
+                        BufferedImage textureImage = ImageUtils.copy(texture.getImage());
+                        BufferedImage paletteImage = palette.getImage();
+                        BufferedImage keyPaletteImage = keyPalette.getImage();
+                        
+                        Map<Integer, Integer> paletteMap = new HashMap<>();
+                        for (int x=0; x<paletteImage.getWidth(); x++) {
+                                int keyColour = keyPaletteImage.getRGB(x, 0);
+                                int palettedColour = paletteImage.getRGB(x, 0);
+                                paletteMap.put(keyColour, palettedColour);
+                        }
+                        
+                        for (int x=0; x<textureImage.getWidth(); x++)
+                        {
+                                for (int y=0; y<textureImage.getHeight(); y++)
+                                {
+                                        int colour = textureImage.getRGB(x, y);
+                                        if (colour != 0) {
+                                                colour = paletteMap.get(colour);
+                                                textureImage.setRGB(x, y, colour);
+                                        }
+                                }
+                        }
+                                            
+                        tex = new PackTexture(rasteriser, path, textureImage);
+                        loadedPackTextures.put(path, tex);
+                }
+                
+                return tex;
+        }
 	
 	private PackTexture findTexture(TextureRequest request, boolean logMissingTextures) {
 		PackTexture tex = loadedPackTextures.get(request.path);

--- a/src/main/java/tectonicus/texture/TexturePack.java
+++ b/src/main/java/tectonicus/texture/TexturePack.java
@@ -314,7 +314,7 @@ public class TexturePack
 
 		TextureRequest request = parseRequest(texturePath);
 
-		PackTexture tex = findTexture(request); // find existing PackTexture or load
+		PackTexture tex = findTexture(request, false); // find existing PackTexture or load
 
 		if (tex != null) {
 			result = tex.find(request, version); // find existing SubTexture or load
@@ -334,7 +334,7 @@ public class TexturePack
 
 		TextureRequest request = parseRequest(texturePath);
 
-		PackTexture tex = findTexture(request); // find existing PackTexture or load
+		PackTexture tex = findTexture(request, true); // find existing PackTexture or load
 
 		if (tex != null) {
 			result = tex.find(request, version); // find existing SubTexture or load
@@ -353,7 +353,7 @@ public class TexturePack
 
 		TextureRequest request = new TextureRequest("assets/minecraft/textures/" + texturePath, "");
 
-		PackTexture tex = findTexture(request); // find existing PackTexture or load
+		PackTexture tex = findTexture(request, true); // find existing PackTexture or load
 
 		if (tex != null) {
 			result = tex.find(request, version); // find existing SubTexture or load
@@ -423,7 +423,7 @@ public class TexturePack
 		return pathPrefix;
 	}
 	
-	private PackTexture findTexture(TextureRequest request) {
+	private PackTexture findTexture(TextureRequest request, boolean logMissingTextures) {
 		PackTexture tex = loadedPackTextures.get(request.path);
 		
 		if (tex == null) {
@@ -458,7 +458,9 @@ public class TexturePack
 					loadedPackTextures.put(request.path, tex);
 				}
 			} catch (FileNotFoundException e) {
-				log.warn("\nThe texture file '" + request.path + "' could not be found.");
+                                if (logMissingTextures) {
+                                        log.warn("\nThe texture file '" + request.path + "' could not be found.");
+                                }
 			}
 		}
 		

--- a/src/main/resources/defaultBlockConfig.xml
+++ b/src/main/resources/defaultBlockConfig.xml
@@ -169,6 +169,8 @@
 	<Bell stringId="minecraft:bell" name="Bell" texture="assets/minecraft/textures/entity/bell/bell_body.png" />
         
         <DecoratedPot stringId="minecraft:decorated_pot" name="Decorated pot" />
+        
+        <ChiseledBookshelf stringId="minecraft:chiseled_bookshelf" name="Chiseled bookshelf" />
 
 	<PaintingNew id="-1" name="Paintings" />
 	<ItemFrameNew id="-2" name="Item Frame" background="item_frame.png" glowBackground="glow_item_frame.png" border="birch_planks.png" map="assets/minecraft/textures/map/map_background.png" />

--- a/src/main/resources/defaultBlockConfig.xml
+++ b/src/main/resources/defaultBlockConfig.xml
@@ -168,10 +168,11 @@
 
 	<Bell stringId="minecraft:bell" name="Bell" texture="assets/minecraft/textures/entity/bell/bell_body.png" />
         
-        <DecoratedPot stringId="minecraft:decorated_pot" name="Decorated pot" />
+        <DecoratedPot stringId="minecraft:decorated_pot" name="Decorated Pot" />
         
-        <ChiseledBookshelf stringId="minecraft:chiseled_bookshelf" name="Chiseled bookshelf" />
-
+        <ChiseledBookshelf stringId="minecraft:chiseled_bookshelf" name="Chiseled Bookshelf" />
+        
 	<PaintingNew id="-1" name="Paintings" />
 	<ItemFrameNew id="-2" name="Item Frame" background="item_frame.png" glowBackground="glow_item_frame.png" border="birch_planks.png" map="assets/minecraft/textures/map/map_background.png" />
+        <ArmorStand id="-3" name="Armor Stand" />
 </blockConfig>

--- a/src/main/resources/defaultBlockConfigMC1.13.xml
+++ b/src/main/resources/defaultBlockConfigMC1.13.xml
@@ -119,8 +119,8 @@
 	<ShulkerBox stringId="minecraft:black_shulker_box" name="Black Shulker Box" />
 
 	<Conduit stringId="minecraft:conduit" name="Conduit" texture="assets/minecraft/textures/entity/conduit/base.png" />
-
+        
 	<Painting id="-1" name="Paintings" texture="assets/minecraft/textures/painting/paintings_kristoffer_zetterstrand.png" />
-
 	<ItemFrameNew id="-2" name="Item Frame" background="item_frame.png" border="birch_planks.png" map="assets/minecraft/textures/map/map_background.png" />
+        <ArmorStand id="-3" name="Armor Stand" />
 </blockConfig>

--- a/src/main/resources/defaultBlockConfigMC1.14.xml
+++ b/src/main/resources/defaultBlockConfigMC1.14.xml
@@ -131,8 +131,8 @@
 	<Conduit stringId="minecraft:conduit" name="Conduit" texture="assets/minecraft/textures/entity/conduit/base.png" />
 
 	<Bell stringId="minecraft:bell" name="Bell" texture="assets/minecraft/textures/entity/bell/bell_body.png" />
-
+        
 	<PaintingNew id="-1" name="Paintings" />
-
 	<ItemFrameNew id="-2" name="Item Frame" background="item_frame.png" border="birch_planks.png" map="assets/minecraft/textures/map/map_background.png" />
+        <ArmorStand id="-3" name="Armor Stand" />
 </blockConfig>

--- a/src/main/resources/defaultBlockConfigMC1.15-1.19.xml
+++ b/src/main/resources/defaultBlockConfigMC1.15-1.19.xml
@@ -141,7 +141,8 @@
 	<Conduit stringId="minecraft:conduit" name="Conduit" texture="assets/minecraft/textures/entity/conduit/base.png" />
 
 	<Bell stringId="minecraft:bell" name="Bell" texture="assets/minecraft/textures/entity/bell/bell_body.png" />
-
+        
 	<PaintingNew id="-1" name="Paintings" />
 	<ItemFrameNew id="-2" name="Item Frame" background="item_frame.png" glowBackground="glow_item_frame.png" border="birch_planks.png" map="assets/minecraft/textures/map/map_background.png" />
+        <ArmorStand id="-3" name="Armor Stand" />
 </blockConfig>


### PR DESCRIPTION
Thank you for merging my last pull request. Now I have added fire, wind, etc. paintings from #190 and chiseled bookshelves from #220.

I have also looked at the paletted permutations mentioned in #220 and added a method to get paletted texture. As far as I can tell it is only used in armor trims, but armor stands were not implemented, so I added those too...

Here is how it all looks:

![tile_-1_-1](https://github.com/tectonicus/tectonicus/assets/51075039/f828c8b2-e202-481d-8ad3-8d2ed77a57e8)

![Screenshot 2024-03-23 085349](https://github.com/tectonicus/tectonicus/assets/51075039/a53c6da8-e0a5-454c-ba76-527b1a841a62)

![Screenshot 2024-03-23 181455](https://github.com/tectonicus/tectonicus/assets/51075039/5818db7d-f314-4c76-857c-3f34509cf7ea)

The armor stands were added all the way back in 1.8, but I only added support for them from 1.13 and up. They are complicated enough as it is and I did not want to make it worse by also handling numeric IDs... I have tested them in both 1.20 and 1.13 worlds though and everything worked...