### PR TITLE
Configurable view resolution

### DIFF
--- a/Docs/fullConfig.xml
+++ b/Docs/fullConfig.xml
@@ -75,6 +75,8 @@
 			imageCompressionLevel="0.95 / 0.1 - 1.0"
 			drawDistance="200"
 			fov="70 / 30 - 110"
+                        width="1920 / 640 - 3840"
+                        height="1080 / 480 - 2160"
 		/>
 
 		<players

--- a/src/main/java/tectonicus/InteractiveRenderer.java
+++ b/src/main/java/tectonicus/InteractiveRenderer.java
@@ -20,6 +20,7 @@ import org.joml.Vector4f;
 import tectonicus.view.ViewUtil;
 import tectonicus.view.ViewUtil.Viewpoint;
 import tectonicus.configuration.Configuration;
+import tectonicus.configuration.MutableViewConfig;
 import tectonicus.rasteriser.Mesh;
 import tectonicus.rasteriser.PrimativeType;
 import tectonicus.rasteriser.Rasteriser;
@@ -283,8 +284,10 @@ public class InteractiveRenderer
 				Vector3f forward = new Vector3f((float)Math.cos(angleRad), 0, (float)Math.sin(angleRad));
 				Vector3f lookAt = new Vector3f(eye.x + forward.x, eye.y + forward.y, eye.z + forward.z);
 			*/	
-				Viewpoint view = ViewUtil.findView(new tectonicus.world.Sign(perspectiveSign));
-				perspectiveCamera = ViewUtil.createCamera(rasteriser, view, 300);
+                                Viewpoint view = ViewUtil.findView(new tectonicus.world.Sign(perspectiveSign));
+                                MutableViewConfig viewConfig = new MutableViewConfig();
+                                viewConfig.setViewDistance(300);
+				perspectiveCamera = ViewUtil.createCamera(rasteriser, view, viewConfig);
 				
 			//	perspectiveCamera.lookAt(eye, lookAt, up, 90.0f, 1.0f, 0.1f, 100f);
 				

--- a/src/main/java/tectonicus/TileRenderer.java
+++ b/src/main/java/tectonicus/TileRenderer.java
@@ -31,6 +31,7 @@ import tectonicus.configuration.Layer;
 import tectonicus.rasteriser.Rasteriser;
 import tectonicus.rasteriser.RasteriserFactory;
 import tectonicus.rasteriser.RasteriserFactory.DisplayType;
+import tectonicus.raw.ContainerEntity;
 import tectonicus.raw.RawChunk;
 import tectonicus.renderer.OrthoCamera;
 import tectonicus.texture.TexturePack;
@@ -61,7 +62,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static tectonicus.Version.VERSION_13;
-import tectonicus.raw.ContainerEntity;
 import static tectonicus.util.OutputResourcesUtil.outputBeds;
 import static tectonicus.util.OutputResourcesUtil.outputChests;
 import static tectonicus.util.OutputResourcesUtil.outputContents;
@@ -193,11 +193,6 @@ public class TileRenderer
 	public void abort()
 	{
 		this.abort = true;
-	}
-	
-	public Rasteriser getRasteriser()
-	{
-		return rasteriser;
 	}
 	
 	public Result output()

--- a/src/main/java/tectonicus/configuration/MutableViewConfig.java
+++ b/src/main/java/tectonicus/configuration/MutableViewConfig.java
@@ -11,11 +11,17 @@ package tectonicus.configuration;
 
 public class MutableViewConfig implements ViewConfig
 {
+	public static final int DEFAULT_WIDTH = 1920;
+	public static final int DEFAULT_HEIGHT = 1080;
+        
 	private ImageFormat imageFormat;
 	private float imageCompressionLevel;
 	
 	private int viewDistance;
 	private int fov;
+        
+        private int width;
+        private int height;
 	
 	public MutableViewConfig()
 	{
@@ -23,6 +29,8 @@ public class MutableViewConfig implements ViewConfig
 		this.imageCompressionLevel = 0.95f;
 		this.viewDistance = 100;
 		this.fov = 70;
+                this.width = DEFAULT_WIDTH;
+                this.height = DEFAULT_HEIGHT;
 	}
 	
 	@Override
@@ -69,4 +77,22 @@ public class MutableViewConfig implements ViewConfig
 	{
 		this.fov = fov;
 	}
+
+        @Override
+        public int getWidth() {
+                return width;
+        }
+        
+        public void setWidth(int width) {
+                this.width = width;
+        }
+
+        @Override
+        public int getHeight() {
+                return height;
+        }
+
+        public void setHeight(int height) {
+                this.height = height;
+        }
 }

--- a/src/main/java/tectonicus/configuration/ParseUtil.java
+++ b/src/main/java/tectonicus/configuration/ParseUtil.java
@@ -168,7 +168,45 @@ public class ParseUtil
 		
 		return 70;
 	}
-	
+        
+        public static int parseWidth(String widthStr)
+	{
+		try
+		{
+			final int width = Integer.parseInt(widthStr);
+			
+			if (width < 640)
+				return 640;
+			
+			if (width > 3840)
+				return 3840;
+			
+			return width;
+		}
+		catch (Exception e) {}
+		
+		return MutableViewConfig.DEFAULT_WIDTH;
+	}
+
+        public static int parseHeight(String heightStr)
+	{
+		try
+		{
+			final int height = Integer.parseInt(heightStr);
+			
+			if (height < 480)
+				return 480;
+			
+			if (height > 2160)
+				return 2160;
+			
+			return height;
+		}
+		catch (Exception e) {}
+		
+		return MutableViewConfig.DEFAULT_HEIGHT;
+	}
+
 	public static SignFilter parseSignFilter(String filterStr) {
 		SignFilterType filterType;
 

--- a/src/main/java/tectonicus/configuration/ViewConfig.java
+++ b/src/main/java/tectonicus/configuration/ViewConfig.java
@@ -19,4 +19,8 @@ public interface ViewConfig
 	
 	int getFOV();
 	void setFOV(int fov);
+        
+        int getWidth();
+        
+        int getHeight();
 }

--- a/src/main/java/tectonicus/configuration/XmlConfigurationParser.java
+++ b/src/main/java/tectonicus/configuration/XmlConfigurationParser.java
@@ -45,6 +45,7 @@ import static tectonicus.configuration.ParseUtil.parseDimension;
 import static tectonicus.configuration.ParseUtil.parseDrawDistance;
 import static tectonicus.configuration.ParseUtil.parseElevationAngle;
 import static tectonicus.configuration.ParseUtil.parseFOV;
+import static tectonicus.configuration.ParseUtil.parseHeight;
 import static tectonicus.configuration.ParseUtil.parseImageCompression;
 import static tectonicus.configuration.ParseUtil.parseImageFormat;
 import static tectonicus.configuration.ParseUtil.parseLightStyle;
@@ -67,6 +68,7 @@ import static tectonicus.configuration.ParseUtil.parseSinglePlayerName;
 import static tectonicus.configuration.ParseUtil.parseTileSize;
 import static tectonicus.configuration.ParseUtil.parseUseDefaultBlockConfig;
 import static tectonicus.configuration.ParseUtil.parseViewFilter;
+import static tectonicus.configuration.ParseUtil.parseWidth;
 
 @Log4j2
 @UtilityClass
@@ -236,6 +238,12 @@ public class XmlConfigurationParser
 				
 				final int fov = parseFOV( getString(viewsNode, "fov") );
 				viewConfig.setFOV(fov);
+
+				final int width = parseWidth( getString(viewsNode, "width") );
+				viewConfig.setWidth(width);
+
+				final int height = parseHeight( getString(viewsNode, "height") );
+				viewConfig.setHeight(height);
 			}
 			
 			// Player filter

--- a/src/main/java/tectonicus/view/ViewUtil.java
+++ b/src/main/java/tectonicus/view/ViewUtil.java
@@ -23,15 +23,13 @@ import org.joml.Vector3f;
 import tectonicus.Minecraft;
 import tectonicus.configuration.ImageFormat;
 import tectonicus.configuration.LightStyle;
+import tectonicus.configuration.ViewConfig;
 import tectonicus.rasteriser.Rasteriser;
 import tectonicus.renderer.PerspectiveCamera;
 import tectonicus.world.Sign;
 
 @UtilityClass
 public class ViewUtil {
-	public static final int VIEW_WIDTH = 2048;
-	public static final int VIEW_HEIGHT = 1152;
-
 	@Getter
 	@AllArgsConstructor
 	public static class Viewpoint {
@@ -197,9 +195,9 @@ public class ViewUtil {
 	}
 	
 	
-	public static PerspectiveCamera createCamera(Rasteriser rasteriser, Viewpoint view, final int drawDistance) {
-		PerspectiveCamera perspectiveCamera = new PerspectiveCamera(rasteriser, VIEW_WIDTH, VIEW_HEIGHT);
-		perspectiveCamera.lookAt(view.getEye(), view.getLookAt(), view.getUp(), view.getFov(), (float) VIEW_WIDTH /(float) VIEW_HEIGHT, 0.1f, drawDistance);
+	public static PerspectiveCamera createCamera(Rasteriser rasteriser, Viewpoint view, ViewConfig viewConfig) {
+                PerspectiveCamera perspectiveCamera = new PerspectiveCamera(rasteriser, viewConfig.getWidth(), viewConfig.getHeight());
+		perspectiveCamera.lookAt(view.getEye(), view.getLookAt(), view.getUp(), view.getFov(), (float) viewConfig.getWidth() /(float) viewConfig.getHeight(), 0.1f, viewConfig.getViewDistance());
 		
 		return perspectiveCamera;
 	}


### PR DESCRIPTION
The view resolution was fixed at 1024x576, because the views were rendered at double the width and height and the rasteriser window size is only 2048x2048, so larger views do not fit.

I have changed it so that larger view resolutions are possible and are rendered as 2048x2048 tiles, which are then combined into the final larger view.

I have then increased the default view resolution to 1080p and added option to configure the view resolution up to 4K resolution.