### PR TITLE
Render items

### DIFF
--- a/src/main/java/tectonicus/ItemRenderer.java
+++ b/src/main/java/tectonicus/ItemRenderer.java
@@ -181,13 +181,17 @@ public class ItemRenderer
 		renderBlock(outFile, null, context, rawChunk, null, model, 32);
 	}
 
-	public void renderBlockModelName(File outFile, BlockRegistry registry, TexturePack texturePack, String modelName) throws Exception {
-		RawChunk rawChunk = new RawChunk();
+	public void renderInventoryBlockModel(File outFile, BlockRegistry registry, TexturePack texturePack, String modelName) throws Exception {
 		BlockModel model = registry.getModel(modelName);
+                renderInventoryBlockModel(outFile, registry, texturePack, model);
+	}
+        
+        public void renderInventoryBlockModel(File outFile, BlockRegistry registry, TexturePack texturePack, BlockModel model) throws Exception {
+                RawChunk rawChunk = new RawChunk();
 		ItemContext context = new ItemContext(texturePack, null, registry);
                 BoundingBox bounds = new BoundingBox(new Vector3f(0, 0, 0), 1, 1, 1);
 		renderBlock(outFile, null, context, rawChunk, null, model, 48, getAngleRad(270 + 45), getAngleRad(30), bounds);
-	}
+        }
 
 	public void renderBlock(File outFile, BlockTypeRegistry registry, TexturePack texturePack, Block block, BlockProperties properties) throws Exception {
 		String blockName = block.getName();
@@ -262,7 +266,7 @@ public class ItemRenderer
         
         public void renderBed(File outFile, BlockTypeRegistry registry, TexturePack texturePack, String modelName) throws Exception
 	{
-                BoundingBox bounds = new BoundingBox(new Vector3f(-1, -1, 0), 2, 1, 0);
+                BoundingBox bounds = new BoundingBox(new Vector3f(-1.25f, -1, 0), 2.5f, 1.25f, 0);
                 
                 renderBed(outFile, registry, texturePack, 48, bounds, modelName);
         }
@@ -318,6 +322,8 @@ public class ItemRenderer
                 float cameraAngle = getAngleRad(45 + 270);
                 float cameraElevationAngle = getAngleRad(30);
 
+                /* TODO: Figure out transforms. Both scaling and translation are all over the place.
+                         Some items benefit from them, others are too small, or weirdly offset, dragon head is a total mess.
                 for (var transform : transforms) {
                         float translateX = 0;
                         float translateY = 0;
@@ -337,14 +343,12 @@ public class ItemRenderer
                                 scaleY = scale.get(1);
                                 scaleZ = scale.get(2);
                         }
-                        /* TODO: Figure out translation. It does some weird stuff with skulls and mainly with the dragon head when enabled.
                         if (transform != null && transform.containsKey("translation")) {
                                 ArrayList<Float> translation = transform.get("translation");
                                 translateX = translation.get(0);
                                 translateY = translation.get(1);
                                 translateZ = translation.get(2);
                         }
-                        */
 
                         // Do the scaling. Divide insted of multiply, since we are transforming bounding box instead of item
                         final float centerX = bounds.getCenterX();
@@ -360,6 +364,7 @@ public class ItemRenderer
                                 scaledWidth, scaledHeight, scaledDepth
                         );
                 }
+                */
                 
                 renderBlock(outFile, registry, context, rawChunk, type, null, 48, cameraAngle, cameraElevationAngle, bounds);
         }        

--- a/src/main/java/tectonicus/ItemRenderer.java
+++ b/src/main/java/tectonicus/ItemRenderer.java
@@ -35,7 +35,6 @@ import tectonicus.raw.BiomesOld;
 import tectonicus.raw.BlockProperties;
 import tectonicus.raw.RawChunk;
 import tectonicus.raw.SignEntity;
-import tectonicus.raw.SkullEntity;
 import tectonicus.renderer.Geometry;
 import tectonicus.renderer.OrthoCamera;
 import tectonicus.texture.SubTexture;
@@ -53,6 +52,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 @Log4j2
 public class ItemRenderer
@@ -185,8 +185,8 @@ public class ItemRenderer
 		RawChunk rawChunk = new RawChunk();
 		BlockModel model = registry.getModel(modelName);
 		ItemContext context = new ItemContext(texturePack, null, registry);
-                BoundingBox bounds = new BoundingBox(new Vector3f(1, 0.17f, 1), 1, 1, 1);
-		renderBlock(outFile, null, context, rawChunk, null, model, 48, getAngleRad(225), getAngleRad(25), bounds);
+                BoundingBox bounds = new BoundingBox(new Vector3f(0, 0, 0), 1, 1, 1);
+		renderBlock(outFile, null, context, rawChunk, null, model, 48, getAngleRad(270 + 45), getAngleRad(30), bounds);
 	}
 
 	public void renderBlock(File outFile, BlockTypeRegistry registry, TexturePack texturePack, Block block, BlockProperties properties) throws Exception {
@@ -200,7 +200,7 @@ public class ItemRenderer
 	}
         
 	private void renderBlock(File outFile, BlockTypeRegistry registry, ItemContext context, RawChunk rawChunk, BlockType type, BlockModel model, int imageSize) throws Exception {
-                renderBlock(outFile, registry, context, rawChunk, type, model, imageSize, getAngleRad(45), getAngleRad(25), new BoundingBox(new Vector3f(0, 0.17f, 0), 1, 1, 1));
+                renderBlock(outFile, registry, context, rawChunk, type, model, imageSize, getAngleRad(45), getAngleRad(25), new BoundingBox(new Vector3f(0, 0, 0), 1, 1, 1));
         }
 
         private void renderBlock(File outFile, BlockTypeRegistry registry, ItemContext context, RawChunk rawChunk, BlockType type, BlockModel model, int imageSize, float cameraAngle, float cameraElevationAngle, BoundingBox bounds) throws Exception {
@@ -245,7 +245,7 @@ public class ItemRenderer
 			type.addInteriorGeometry(0, 0, 0, context, registry, rawChunk, geometry);
 		}
 		
-		BoundingBox bounds = new BoundingBox(new Vector3f(0, 0.4f, 0), 1, 1, 0);
+		BoundingBox bounds = new BoundingBox(new Vector3f(0, 0, 0), 1, 1, 0);
 
 		ItemGeometry item = new ItemGeometry(geometry, bounds);
 		renderItem(item, outFile, 32, 4, getAngleRad(45), getAngleRad(25));
@@ -255,14 +255,14 @@ public class ItemRenderer
 	{
                 log.info("Generating bed icon...");
                 
-                BoundingBox bounds = new BoundingBox(new Vector3f(-1, -0.5f, 0), 2, 1, 0);
+                BoundingBox bounds = new BoundingBox(new Vector3f(-1, -1, 0), 2, 1, 0);
                 
                 renderBed(outFile, registry, texturePack, 32, bounds, "minecraft:red_bed");
         }
         
         public void renderBed(File outFile, BlockTypeRegistry registry, TexturePack texturePack, String modelName) throws Exception
 	{
-                BoundingBox bounds = new BoundingBox(new Vector3f(-1f, -0.5f, 0), 2, 1, 0);
+                BoundingBox bounds = new BoundingBox(new Vector3f(-1, -1, 0), 2, 1, 0);
                 
                 renderBed(outFile, registry, texturePack, 48, bounds, modelName);
         }
@@ -270,7 +270,8 @@ public class ItemRenderer
        	private void renderBed(File outFile, BlockTypeRegistry registry, TexturePack texturePack, int imageSize, BoundingBox bounds, String modelName) throws Exception
         {
                 final String colorString = StringUtils.removeEnd(StringUtils.removeStart(modelName, "minecraft:"), "_bed");
-                final int color = Colors.byName(colorString).getId();
+                final Colors color = Colors.byName(colorString);
+                final int colorId = color == null ? Colors.RED.getId() : color.getId();
                             
 		ItemContext context = new ItemContext(texturePack, registry, null);
 		
@@ -287,8 +288,8 @@ public class ItemRenderer
 		rawChunk.setBlockLight(0, 0, 1, (byte)16);
 		rawChunk.setSkyLight(0, 0, 1, (byte) 16);
 		HashMap<String, BedEntity> beds = new HashMap<>();
-		beds.put("x0y0z0", new BedEntity(0, 0, 0, 0, 0, 0, color));
-		beds.put("x0y0z1", new BedEntity(0, 0, 1, 0, 0, 1, color));
+		beds.put("x0y0z0", new BedEntity(0, 0, 0, 0, 0, 0, colorId));
+		beds.put("x0y0z1", new BedEntity(0, 0, 1, 0, 0, 1, colorId));
 		rawChunk.setBeds(beds);
 		
 		BlockType type = registry.find(BlockIds.BED, 10);
@@ -306,18 +307,61 @@ public class ItemRenderer
 		renderItem(item, outFile, imageSize, 4, getAngleRad(65), getAngleRad(35));
 	}
         
-        // TODO does this need to be separate method? maybe there can be a generalized method to handle every builtin/entity?        
-        public void renderSkull(File outFile, BlockTypeRegistry registry, TexturePack texturePack, String blockName) throws Exception {
+        public void renderItem(File outFile, BlockTypeRegistry registry, TexturePack texturePack, String blockName, List<java.util.Map<String, ArrayList<Float>>> transforms) throws Exception {
 		RawChunk rawChunk = new RawChunk();
 		rawChunk.setBlockName(0, 0, 0, blockName);
 		BlockType type = registry.find(blockName);
 		ItemContext context = new ItemContext(texturePack, registry, null);
                 
-                HashMap<String, SkullEntity> skulls = new HashMap<>();
-		skulls.put("x0y0z0", new SkullEntity(0, 0, 0, 0, 0, 0, 0, 0, 0));
-		rawChunk.setSkulls(skulls);
-		
-                renderBlock(outFile, registry, context, rawChunk, type, null, 48);
+                BoundingBox bounds = new BoundingBox(new org.joml.Vector3f(), 1, 1, 1);
+                
+                float cameraAngle = getAngleRad(45 + 270);
+                float cameraElevationAngle = getAngleRad(30);
+
+                for (var transform : transforms) {
+                        float translateX = 0;
+                        float translateY = 0;
+                        float translateZ = 0;
+                        float scaleX = 1;
+                        float scaleY = 1;
+                        float scaleZ = 1;
+
+                        if (transform != null && transform.containsKey("rotation")) {
+                                ArrayList<Float> rotation = transform.get("rotation");
+                                cameraAngle = getAngleRad(rotation.get(1) + 270);
+                                cameraElevationAngle = getAngleRad(rotation.get(0));
+                        }
+                        if (transform != null && transform.containsKey("scale")) {
+                                ArrayList<Float> scale = transform.get("scale");
+                                scaleX = scale.get(0);
+                                scaleY = scale.get(1);
+                                scaleZ = scale.get(2);
+                        }
+                        /* TODO: Figure out translation. It does some weird stuff with skulls and mainly with the dragon head when enabled.
+                        if (transform != null && transform.containsKey("translation")) {
+                                ArrayList<Float> translation = transform.get("translation");
+                                translateX = translation.get(0);
+                                translateY = translation.get(1);
+                                translateZ = translation.get(2);
+                        }
+                        */
+
+                        // Do the scaling. Divide insted of multiply, since we are transforming bounding box instead of item
+                        final float centerX = bounds.getCenterX();
+                        final float centerY = bounds.getCenterY();
+                        final float centerZ = bounds.getCenterZ();
+                        final float scaledWidth = bounds.getWidth()/scaleX;
+                        final float scaledHeight = bounds.getHeight()/scaleY;
+                        final float scaledDepth = bounds.getDepth()/scaleZ;
+
+                        // Subtract insted of add during translation, since we are transforming bounding box instead of item
+                        bounds = new BoundingBox(
+                                new Vector3f(centerX-scaledWidth/2-translateX, centerY-scaledHeight/2-translateY, centerZ-scaledDepth/2-translateZ),
+                                scaledWidth, scaledHeight, scaledDepth
+                        );
+                }
+                
+                renderBlock(outFile, registry, context, rawChunk, type, null, 48, cameraAngle, cameraElevationAngle, bounds);
         }        
 	
 	private void renderItem(ItemGeometry item, File outFile, final int imageSize, final int numDownsamples, final float cameraAngle, final float cameraElevationAngle)
@@ -421,7 +465,7 @@ public class ItemRenderer
 		Screenshot.write(outFile, outImg, ImageFormat.Png, 1.0f);
 	}
 	
-	private float getAngleRad(int angle)
+	private float getAngleRad(float angle)
 	{
 		final float normalised = (float)angle / 360.0f;
 		return normalised * (float)Math.PI * 2.0f;

--- a/src/main/java/tectonicus/ItemRenderer.java
+++ b/src/main/java/tectonicus/ItemRenderer.java
@@ -681,17 +681,17 @@ public class ItemRenderer
 		@Override
 		public Biome getBiome(ChunkCoord chunkCoord, int x, int y, int z)
 		{
-			return BiomesOld.OCEAN;
+			return BiomesOld.FOREST;
 		}
 
 		@Override
 		public Colour4f getGrassColor(ChunkCoord chunkCoord, int x, int y, int z) {
-			return new Colour4f(1, 1, 1, 1);
+			return texturePack.getGrassColor(BiomesOld.FOREST);
 		}
 
 		@Override
 		public Colour4f getFoliageColor(ChunkCoord chunkCoord, int x, int y, int z) {
-			return new Colour4f(1, 1, 1, 1);
+			return texturePack.getFoliageColor(BiomesOld.FOREST);
 		}
 
 		@Override

--- a/src/main/java/tectonicus/TileRenderer.java
+++ b/src/main/java/tectonicus/TileRenderer.java
@@ -65,12 +65,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static tectonicus.Version.VERSION_13;
 import static tectonicus.util.OutputResourcesUtil.outputBeds;
-import static tectonicus.util.OutputResourcesUtil.outputBlockItemIcons;
 import static tectonicus.util.OutputResourcesUtil.outputChests;
 import static tectonicus.util.OutputResourcesUtil.outputContents;
 import static tectonicus.util.OutputResourcesUtil.outputHtml;
 import static tectonicus.util.OutputResourcesUtil.outputHtmlResources;
 import static tectonicus.util.OutputResourcesUtil.outputIcons;
+import static tectonicus.util.OutputResourcesUtil.outputInventoryItemIcons;
 import static tectonicus.util.OutputResourcesUtil.outputPlayers;
 import static tectonicus.util.OutputResourcesUtil.outputPortals;
 import static tectonicus.util.OutputResourcesUtil.outputRenderStats;
@@ -310,7 +310,7 @@ public class TileRenderer
                         System.out.println("Unable to render. No map is defined in config.");
                 } else {
                         ItemRegistry itemRegistry = new ItemRegistry(world.getTexturePack());
-                        outputBlockItemIcons(config, rasteriser, world.getTexturePack(), world.getBlockTypeRegistry(), world.getModelRegistry(), itemRegistry);
+                        outputInventoryItemIcons(config, rasteriser, world.getTexturePack(), world.getBlockTypeRegistry(), world.getModelRegistry(), itemRegistry);
                         outputHtmlResources(world.getTexturePack(), playerIconAssembler, config, exportDir, numZoomLevels, tileWidth, tileHeight);
                 }
 		

--- a/src/main/java/tectonicus/blockTypes/Banner.java
+++ b/src/main/java/tectonicus/blockTypes/Banner.java
@@ -31,6 +31,7 @@ import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -107,7 +108,14 @@ public class Banner implements BlockType
 	@Override
 	public void addEdgeGeometry(final int x, final int y, final int z, BlockContext world, BlockTypeRegistry registry, RawChunk rawChunk, Geometry geometry)
 	{
-		int data = rawChunk.getBlockData(x, y, z);
+		String xyz = "x" + x + "y" + y + "z" + z;
+		BannerEntity entity = rawChunk.getBanners().get(xyz);
+                if (entity == null) {
+                        // There is no entity when rendering item icons. Use default values...
+                        entity = new BannerEntity(0, 0, 0, 0, 0, 0, 0, new ArrayList<>());
+                }
+                
+                int data = rawChunk.getBlockData(x, y, z);
 		final BlockProperties properties = rawChunk.getBlockState(x, y, z);
 		if (properties != null && properties.containsKey("facing")) {
 			final String facing = properties.get("facing");
@@ -132,8 +140,6 @@ public class Banner implements BlockType
 		}
 		
 		SubMesh subMesh = new SubMesh();
-		String xyz = "x" + x + "y" + y + "z" + z;
-		BannerEntity entity = rawChunk.getBanners().get(xyz);
 		Colors baseColor = Colors.byId(15-entity.getBaseColor());
 		if (StringUtils.isNotEmpty(id)) {
 			String bannerId = id.replace("minecraft:", "").replace("_wall", "").replace("_banner", "");

--- a/src/main/java/tectonicus/blockTypes/ChestNew.java
+++ b/src/main/java/tectonicus/blockTypes/ChestNew.java
@@ -140,7 +140,8 @@ public class ChestNew implements BlockType
 		SubMesh rightDoubleChestMesh = new SubMesh();
 
 		Rotation horizRotation = Rotation.Clockwise;
-		float horizAngle = 0;
+		float horizAngle = 180;
+                String type = null;
 		final BlockProperties properties = chunk.getBlockState(x, y, z);
 		if (properties != null) {
 			switch (properties.get("facing")) {
@@ -159,17 +160,20 @@ public class ChestNew implements BlockType
 					eastWestColorTemp = northSouthColor;
 					break;
 				default:
+                                        horizAngle = 0;
+                                        break;
 			}
 
-			String type = properties.get("type");
-			if (type != null && type.equals("left")) {
-				addLeftHalfDoubleChest(leftDoubleChestMesh, topColor, northSouthColorTemp, eastWestColorTemp);
-			} else if (type != null && type.equals("right")) {
-				addRightHalfDoubleChest(rightDoubleChestMesh, topColor, northSouthColorTemp, eastWestColorTemp);
-			} else {
-				addSingleChest(singleChestMesh, topColor, northSouthColorTemp, eastWestColorTemp);
-			}
+			type = properties.get("type");
 		}
+                
+                if (type != null && type.equals("left")) {
+                        addLeftHalfDoubleChest(leftDoubleChestMesh, topColor, northSouthColorTemp, eastWestColorTemp);
+                } else if (type != null && type.equals("right")) {
+                        addRightHalfDoubleChest(rightDoubleChestMesh, topColor, northSouthColorTemp, eastWestColorTemp);
+                } else {
+                        addSingleChest(singleChestMesh, topColor, northSouthColorTemp, eastWestColorTemp);
+                }
 
 		singleChestMesh.pushTo(geometry.getMesh(smallTop.texture, Geometry.MeshType.Solid), x, y, z, horizRotation, horizAngle, Rotation.None, 0);
 		leftDoubleChestMesh.pushTo(geometry.getMesh(leftTop.texture, Geometry.MeshType.Solid), x, y, z, horizRotation, horizAngle, Rotation.None, 0);

--- a/src/main/java/tectonicus/blockTypes/DecoratedPot.java
+++ b/src/main/java/tectonicus/blockTypes/DecoratedPot.java
@@ -111,6 +111,10 @@ public class DecoratedPot implements BlockType
                 
                 String xyz = "x" + x + "y" + y + "z" + z;
                 DecoratedPotEntity pot = rawChunk.getDecoratedPots().get(xyz);
+                if (pot == null) {
+                        // There is no entity when rendering item icons. Use default values...
+                        pot = new DecoratedPotEntity(0, 0, 0, 0, 0, 0, "minecraft:brick", "minecraft:brick", "minecraft:brick", "minecraft:brick");
+                }
                 
                 final SubTexture side1Texture = getSideTexture(pot.getSherd1());
                 final SubTexture side2Texture = getSideTexture(pot.getSherd2());
@@ -225,9 +229,12 @@ public class DecoratedPot implements BlockType
         
         private static int getRotationAngle(int x, int y, int z, RawChunk rawChunk) {
                 final BlockProperties properties = rawChunk.getBlockState(x, y, z);
-                final String facing = properties.get("facing");
-		
-                switch (facing) {
+                
+                if (properties == null) {
+                        return 0;
+                }
+
+                switch (properties.get("facing")) {
                         case "north":
                                 return 180;
                         case "west":

--- a/src/main/java/tectonicus/blockTypes/Skull.java
+++ b/src/main/java/tectonicus/blockTypes/Skull.java
@@ -89,6 +89,10 @@ public class Skull implements BlockType
         {
 		String xyz = "x" + x + "y" + y + "z" + z;
                 SkullEntity skullEntity = rawChunk.getSkulls().get(xyz);
+                if (skullEntity == null) {
+                        // There is no entity when rendering item icons. Use default values...
+                        skullEntity = new SkullEntity(0, 0, 0, 0, 0, 0, 0, 0, 0);
+                }
                 addEdgeGeometry(x, y, z, world, registry, rawChunk, geometry, skullEntity);
         }
 

--- a/src/main/java/tectonicus/blockTypes/Skull.java
+++ b/src/main/java/tectonicus/blockTypes/Skull.java
@@ -107,7 +107,7 @@ public class Skull implements BlockType
 		}
 		int rotationValue;
 		if (rotationString != null) {
-			rotationValue = Integer.parseInt(properties.get("rotation"));
+			rotationValue = Integer.parseInt(rotationString);
 		} else {
 			rotationValue = entity.getRotation();
 		}

--- a/src/main/java/tectonicus/blockregistry/BlockRegistry.java
+++ b/src/main/java/tectonicus/blockregistry/BlockRegistry.java
@@ -49,7 +49,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import static tectonicus.blockregistry.BlockStateWrapper.getRandomWeightedModel;
+import static tectonicus.blockregistry.BlockState.getRandomWeightedModel;
 
 
 @Log4j2
@@ -169,7 +169,7 @@ public class BlockRegistry
 							}
 						}
 
-						states.addCase(new BlockStateCase(whenClauses, new BlockStateModelsWeight(deserializeBlockStateModels(node.get("apply")))));
+						states.addState(new BlockStateCase(whenClauses, new BlockStateModelsWeight(deserializeBlockStateModels(node.get("apply")))));
 					});
 				} else if (root.has("variants")) {
 					JsonNode variants = root.get("variants");
@@ -184,7 +184,7 @@ public class BlockRegistry
 							singleVariantBlocks.put(name, modelsAndWeight);
 						}
 						BlockVariant blockVariant = new BlockVariant(key, modelsAndWeight);
-						states.addVariant(blockVariant);
+						states.addState(blockVariant);
 					}
 				} else {
 					log.warn("Invalid blockstate file: {}", blockStateFile);
@@ -355,15 +355,8 @@ public class BlockRegistry
 
 	private void checkBlockAttributes() {
 		for (BlockStateWrapper wrapper : blockStates.asMap().values()) {
-			List<BlockStateCase> cases = wrapper.getCases();
-			if (!cases.isEmpty()) {
-				for (BlockStateCase c : cases) {
-					setBlockAttributes(wrapper, c.getModelsAndWeight().getModels());
-				}
-			} else {
-				for (BlockVariant variant : wrapper.getVariants()) {
-					setBlockAttributes(wrapper, variant.getModelsAndWeight().getModels());
-				}
+                        for (BlockState state : wrapper.getStates()) {
+				setBlockAttributes(wrapper, state.getModelsAndWeight().getModels());
 			}
 		}
 	}

--- a/src/main/java/tectonicus/blockregistry/BlockState.java
+++ b/src/main/java/tectonicus/blockregistry/BlockState.java
@@ -9,6 +9,24 @@
 
 package tectonicus.blockregistry;
 
-public interface BlockState {
-	BlockStateModelsWeight getModelsAndWeight();
+import java.util.List;
+import tectonicus.raw.BlockProperties;
+
+public abstract class BlockState {
+	abstract BlockStateModelsWeight getModelsAndWeight();
+        abstract void addModels(List<BlockStateModel> models, BlockProperties properties);
+        
+	//TODO: We need to do similar to whatever Minecraft does so that the same model is always chosen for specific block coordinates
+	public static BlockStateModel getRandomWeightedModel(BlockStateModelsWeight modelsAndWeight) {
+		int totalWeight = modelsAndWeight.getTextureWeightSum();
+		List<BlockStateModel> models = modelsAndWeight.getModels();
+
+		int idx = 0;
+		for (double r = Math.random() * totalWeight; idx < models.size() - 1; ++idx) {
+			r -= models.get(idx).getWeight();
+			if (r <= 0.0) break;
+		}
+
+		return models.get(idx);
+	}
 }

--- a/src/main/java/tectonicus/blockregistry/BlockStateCase.java
+++ b/src/main/java/tectonicus/blockregistry/BlockStateCase.java
@@ -15,11 +15,34 @@ import lombok.ToString;
 
 import java.util.List;
 import java.util.Map;
+import tectonicus.raw.BlockProperties;
 
 @Builder
 @Getter
 @ToString
-public class BlockStateCase implements BlockState {
+public class BlockStateCase extends BlockState {
 	List<Map<String, String>> whenClauses;
 	BlockStateModelsWeight modelsAndWeight;
+        
+        @Override
+        void addModels(List<BlockStateModel> models, BlockProperties properties) {
+                if (whenClauses.isEmpty()) {  // If no when clauses then always apply models
+                        models.addAll(modelsAndWeight.getModels());
+                } else {
+                        for (Map<String, String> clause : whenClauses) {
+                                boolean addModel = true;
+                                for (Map.Entry<String, String> entry : clause.entrySet()) {
+                                        String key = entry.getKey();
+                                        if (!(properties.containsKey(key) && entry.getValue().contains(properties.get(key)))) {
+                                                addModel = false;
+                                                break;
+                                        }
+                                }
+                                if (addModel) {
+                                        models.add(getRandomWeightedModel(modelsAndWeight));
+                                        break;
+                                }
+                        }
+                }
+        }
 }

--- a/src/main/java/tectonicus/blockregistry/BlockStateWrapper.java
+++ b/src/main/java/tectonicus/blockregistry/BlockStateWrapper.java
@@ -11,18 +11,15 @@ package tectonicus.blockregistry;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
 import tectonicus.raw.BlockProperties;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Getter
 public class BlockStateWrapper {
 	private final String blockName;
-	private final List<BlockStateCase> cases = new ArrayList<>();
-	private final List<BlockVariant> variants = new ArrayList<>();
+	private final List<BlockState> states = new ArrayList<>();
 	@Setter
 	private boolean fullBlock = true;
 	@Setter
@@ -32,76 +29,23 @@ public class BlockStateWrapper {
 		this.blockName = blockName;
 	}
 
-	public void addCase(BlockStateCase bsc) {
-		cases.add(bsc);
-	}
-
-	public void addVariant(BlockVariant variant) {
-		variants.add(variant);
+	public void addState(BlockState state) {
+		states.add(state);
 	}
 
 	public List<BlockStateModel> getModels(BlockProperties properties) {
 		List<BlockStateModel> models = new ArrayList<>();
-		if (!cases.isEmpty()) {
-			for (BlockStateCase bsc : cases) {
-				List<Map<String, String>> whenClauses = bsc.getWhenClauses();
-				if (whenClauses.isEmpty()) {  // If no when clauses then always apply models
-					models.addAll(bsc.getModelsAndWeight().getModels());
-				} else {
-					for (Map<String, String> clause : whenClauses) {
-						boolean addModel = true;
-						for (Map.Entry<String, String> entry : clause.entrySet()) {
-							String key = entry.getKey();
-							if (!(properties.containsKey(key) && entry.getValue().contains(properties.get(key)))) {
-								addModel = false;
-								break;
-							}
-						}
-						if (addModel) {
-							models.add(getRandomWeightedModel(bsc.getModelsAndWeight()));
-							break;
-						}
-					}
-				}
-			}
-		} else {
-			for (BlockVariant variant : variants) {
-				String variantProperties = variant.getName();
-				if (variantProperties.equals(StringUtils.EMPTY) || properties.contains(variantProperties)
-						|| properties.containsAll(variant.getStates())) {
-					models.add(getRandomWeightedModel(variant.getModelsAndWeight()));
-					break;
-				}
-			}
-		}
+                for (BlockState state : states) {
+                        state.addModels(models, properties);
+                }
 		return models;
 	}
 
 	public List<BlockStateModel> getAllModels() {
 		List<BlockStateModel> models = new ArrayList<>();
-		if (!cases.isEmpty()) {
-			for (BlockStateCase bsc : cases) {
-				models.addAll(bsc.getModelsAndWeight().getModels());
-			}
-		} else {
-			for (BlockVariant variant : variants) {
-				models.addAll(variant.getModelsAndWeight().getModels());
-			}
-		}
+                for (BlockState state : states) {
+                        models.addAll(state.getModelsAndWeight().getModels());
+                }
 		return models;
-	}
-
-	//TODO: We need to do similar to whatever Minecraft does so that the same model is always chosen for specific block coordinates
-	public static BlockStateModel getRandomWeightedModel(BlockStateModelsWeight modelsAndWeight) {
-		int totalWeight = modelsAndWeight.getTextureWeightSum();
-		List<BlockStateModel> models = modelsAndWeight.getModels();
-
-		int idx = 0;
-		for (double r = Math.random() * totalWeight; idx < models.size() - 1; ++idx) {
-			r -= models.get(idx).getWeight();
-			if (r <= 0.0) break;
-		}
-
-		return models.get(idx);
 	}
 }

--- a/src/main/java/tectonicus/blockregistry/BlockVariant.java
+++ b/src/main/java/tectonicus/blockregistry/BlockVariant.java
@@ -12,10 +12,13 @@ package tectonicus.blockregistry;
 import lombok.Getter;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import tectonicus.raw.BlockProperties;
 
 @Getter
-public class BlockVariant implements BlockState
+public class BlockVariant extends BlockState
 {
 	private final String name;
 	private final Map<String, String> states;
@@ -38,4 +41,12 @@ public class BlockVariant implements BlockState
 				states.put(state[0], "");
 		}
 	}
+        
+        @Override
+        void addModels(List<BlockStateModel> models, BlockProperties properties) {
+                String variantProperties = name;
+                if (variantProperties.equals(StringUtils.EMPTY) || properties.contains(variantProperties) || properties.containsAll(states)) {
+                        models.add(getRandomWeightedModel(modelsAndWeight));
+                }
+        }
 }

--- a/src/main/java/tectonicus/itemregistry/ItemModel.java
+++ b/src/main/java/tectonicus/itemregistry/ItemModel.java
@@ -11,6 +11,7 @@ package tectonicus.itemregistry;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
 import lombok.Data;
 
 import java.util.Map;
@@ -19,12 +20,11 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ItemModel {
 	private String parent;
-	private Map<String, Integer[]> transform;
+	private Map<String, ArrayList<Float>> transform;
         private Map<String, String> textures;
                 
 	@JsonProperty("display")
-        @SuppressWarnings("unchecked")
-	private void unpackNested(Map<String,Object> brand) {
-		this.transform = (Map<String, Integer[]>)brand.get("gui");
+	private void unpackNested(Map<String, Map<String, ArrayList<Float>>> brand) {
+		this.transform = brand.get("gui");
 	}
 }

--- a/src/main/java/tectonicus/itemregistry/ItemModel.java
+++ b/src/main/java/tectonicus/itemregistry/ItemModel.java
@@ -20,9 +20,11 @@ import java.util.Map;
 public class ItemModel {
 	private String parent;
 	private Map<String, Integer[]> transform;
+        private Map<String, String> textures;
+                
 	@JsonProperty("display")
+        @SuppressWarnings("unchecked")
 	private void unpackNested(Map<String,Object> brand) {
 		this.transform = (Map<String, Integer[]>)brand.get("gui");
 	}
-
 }

--- a/src/main/java/tectonicus/itemregistry/ItemRegistry.java
+++ b/src/main/java/tectonicus/itemregistry/ItemRegistry.java
@@ -24,7 +24,9 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Log4j2
@@ -58,4 +60,30 @@ public class ItemRegistry {
 			models.put(name, itemModel);
 		}
 	}
+        
+        public ItemModel findUltimatePredecessor(ItemModel itemModel) {
+                while (true) {
+                        String parentKey = StringUtils.removeStart(itemModel.getParent(), "minecraft:");
+                        parentKey = StringUtils.removeStart(parentKey, "item/");
+                        if (!models.containsKey(parentKey))
+                        {
+                                return itemModel;
+                        } 
+                        itemModel = models.get(parentKey);
+                }                
+        }
+        
+        public List<Map<String, ArrayList<Float>>> getTransformsList(ItemModel itemModel) {
+                List<Map<String, ArrayList<Float>>> transforms = new ArrayList<>();
+                while (true) {
+                        transforms.add(itemModel.getTransform());
+                        String parentKey = StringUtils.removeStart(itemModel.getParent(), "minecraft:");
+                        parentKey = StringUtils.removeStart(parentKey, "item/");
+                        if (!models.containsKey(parentKey))
+                        {
+                                return transforms;
+                        } 
+                        itemModel = models.get(parentKey);
+                }     
+        }
 }

--- a/src/main/java/tectonicus/raw/RawChunk.java
+++ b/src/main/java/tectonicus/raw/RawChunk.java
@@ -1315,6 +1315,10 @@ public class RawChunk {
 	public Map<String, SkullEntity> getSkulls() {
 		return Collections.unmodifiableMap(skulls);
 	}
+        
+	public void setSkulls(Map<String, SkullEntity> skulls) {
+		this.skulls = skulls;
+	}
 
 	public Map<String, BeaconEntity> getBeacons() {
 		return Collections.unmodifiableMap(beacons);

--- a/src/main/java/tectonicus/texture/TexturePack.java
+++ b/src/main/java/tectonicus/texture/TexturePack.java
@@ -822,7 +822,7 @@ public class TexturePack
 			foliageColors.put(biome, new Colour4f(getFoliageColour(colorCoords.x, colorCoords.y)));
 
 			if(biome == Biomes.DARK_FOREST) {
-				grassColors.replace(biome, new Colour4f((grassColors.get(biome).toInt() & 16711422) + 2634762 >> 1));
+				grassColors.replace(biome, new Colour4f((grassColors.get(biome).toRgb() & 16711422) + 2634762 >> 1));
 			}
 		}
 
@@ -844,7 +844,7 @@ public class TexturePack
 			foliageColorsOld.put(biome, new Colour4f(getFoliageColour(colorCoords.x, colorCoords.y)));
 
 			if(biome == BiomesOld.DARK_FOREST || biome == BiomesOld.DARK_FOREST_HILLS) {
-				grassColorsOld.replace(biome, new Colour4f((grassColorsOld.get(biome).toInt() & 16711422) + 2634762 >> 1));
+				grassColorsOld.replace(biome, new Colour4f((grassColorsOld.get(biome).toRgb() & 16711422) + 2634762 >> 1));
 			}
 		}
 	}

--- a/src/main/java/tectonicus/util/BoundingBox.java
+++ b/src/main/java/tectonicus/util/BoundingBox.java
@@ -18,9 +18,9 @@ import tectonicus.renderer.Camera;
 public class BoundingBox
 {
 	private Vector3f origin;
-	private long width, height, depth;
+	private float width, height, depth;
 	
-	public BoundingBox(Vector3f origin, final long width, final long height, final long depth)
+	public BoundingBox(Vector3f origin, final float width, final float height, final float depth)
 	{
 		this.origin = new Vector3f(origin);
 		this.width = width;
@@ -131,7 +131,7 @@ public class BoundingBox
 		return new Vector3f(origin);
 	}
 	
-	public long getWidth() { return width; }
-	public long getHeight() { return height; }
-	public long getDepth() { return depth; }
+	public float getWidth() { return width; }
+	public float getHeight() { return height; }
+	public float getDepth() { return depth; }
 }

--- a/src/main/java/tectonicus/util/Colour4f.java
+++ b/src/main/java/tectonicus/util/Colour4f.java
@@ -64,7 +64,10 @@ public class Colour4f
 	}
 
 	public Colour4f(int color) {
-		this((color >> 16) & 255, (color >> 8) & 255, color & 255);
+		this.a = ((color >> 24) & 255) / 255f;
+                this.r = ((color >> 16) & 255) / 255f;
+                this.g = ((color >> 8) & 255) / 255f;
+                this.b = ((color >> 0) & 255) / 255f;
 	}
 	
 	public void add(Colour4f other)
@@ -98,11 +101,20 @@ public class Colour4f
 		this.a = (this.a + other.a) / 2;
 	}
 
-	public int toInt() {
+        public int toRgb() {
 		int rgb = (int)(this.r * 255);
 		rgb = (rgb << 8) + (int)(this.g * 255);
 		rgb = (rgb << 8) + (int)(this.b * 255);
 
 		return rgb;
-	}
+        }
+
+        public int toArgb() {
+		int rgb = (int)(this.a * 255);
+                rgb = (rgb << 8) + (int)(this.r * 255);
+		rgb = (rgb << 8) + (int)(this.g * 255);
+		rgb = (rgb << 8) + (int)(this.b * 255);
+
+		return rgb;
+        }
 }

--- a/src/main/java/tectonicus/util/OutputResourcesUtil.java
+++ b/src/main/java/tectonicus/util/OutputResourcesUtil.java
@@ -33,6 +33,7 @@ import tectonicus.itemregistry.ItemModel;
 import tectonicus.itemregistry.ItemRegistry;
 import tectonicus.rasteriser.Rasteriser;
 import tectonicus.raw.ArmorTrimTag;
+import tectonicus.raw.BiomesOld;
 import tectonicus.raw.BlockProperties;
 import tectonicus.raw.ContainerEntity;
 import tectonicus.raw.DisplayTag;
@@ -534,7 +535,7 @@ public class OutputResourcesUtil {
                 return result;
         }
 
-	public static void outputBlockItemIcons(Configuration args, Rasteriser rasteriser, TexturePack texturePack, BlockTypeRegistry blockTypeRegistry, BlockRegistry blockRegistry, ItemRegistry itemRegistry) {
+	public static void outputInventoryItemIcons(Configuration args, Rasteriser rasteriser, TexturePack texturePack, BlockTypeRegistry blockTypeRegistry, BlockRegistry blockRegistry, ItemRegistry itemRegistry) {
                 System.out.println("Rendering icons for inventory items");
                 log.trace("Rendering icons for inventory items");
                 
@@ -595,6 +596,20 @@ public class OutputResourcesUtil {
                                                                 texture = texturePack.loadPalettedTexture(trim, palette, keyPalette);
                                                         } else {
                                                                 texture = texturePack.loadTexture("assets/" + namespace + "/textures/" + textureId + ".png");
+                                                        }
+                                                        
+                                                        var block = blockRegistry.getBlockModels().getIfPresent(layer.getValue());
+                                                        if (block != null) {
+                                                                if (block.getElements().get(0).getFaces().values().iterator().next().isTinted()) {
+                                                                        Colour4f tintColor = texturePack.getFoliageColor(BiomesOld.FOREST);
+                                                                        for (int y=0; y<texture.getHeight(); y++) {
+                                                                                for (int x=0; x<texture.getWidth(); x++) {
+                                                                                        Colour4f pixel = new Colour4f(texture.getRGB(x, y));
+                                                                                        pixel.multiply(tintColor);
+                                                                                        texture.setRGB(x, y, pixel.toArgb());
+                                                                                }
+                                                                        }
+                                                                }
                                                         }
                                                                                                                 
                                                         composited.getGraphics().drawImage(texture, 0, 0, null);

--- a/src/main/java/tectonicus/util/OutputResourcesUtil.java
+++ b/src/main/java/tectonicus/util/OutputResourcesUtil.java
@@ -69,6 +69,7 @@ import java.util.Scanner;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.apache.commons.lang3.StringUtils;
 
 import static tectonicus.Version.VERSION_13;
 import static tectonicus.Version.VERSION_16;
@@ -535,20 +536,29 @@ public class OutputResourcesUtil {
                 return result;
         }
 
-	public static void testOutputItemIcons(Configuration args, tectonicus.configuration.Map map, World world, Rasteriser rasteriser, ItemRegistry itemRegistry) {
-		BlockRegistry registry = world.getModelRegistry();
-		TexturePack texturePack = world.getTexturePack();
-		Version version = world.getWorldInfo().getVersion();
-
+	public static void outputBlockItemIcons(Configuration args, Rasteriser rasteriser, TexturePack texturePack, BlockTypeRegistry blockTypeRegistry, BlockRegistry blockRegistry, ItemRegistry itemRegistry) {
+                System.out.println("Rendering icons for block items");
+                log.trace("Rendering icons for block items");
+                
 		try {
 			ItemRenderer itemRenderer = new ItemRenderer(rasteriser);
 			for (Map.Entry<String, ItemModel> entry : itemRegistry.getModels().entrySet()) {
 				String modelName = entry.getValue().getParent();
+                                
+                                if (modelName == null) {
+                                        // Do not crash for blocks without parent (Air)
+                                        continue;
+                                }
+                                
+                                File outFile = new File(args.getOutputDir(), "Images/Items/" + entry.getKey() + ".png");
+                                
 				if (modelName.contains("block/")) {
-					System.out.println("Rendering icon for: " + modelName);
-					itemRenderer.renderBlockModelName(new File(args.getOutputDir(), "Images/Items/" + entry.getKey() + ".png"), registry, texturePack, modelName);
+					System.out.print("\tRendering icon for: " + modelName + "                    \r"); //prints a carriage return after line
+                                        log.trace("\tRendering icon for: " + modelName);
+					itemRenderer.renderBlockModelName(outFile, blockRegistry, texturePack, modelName);
 				}
 			}
+                        System.out.println();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/tectonicus/util/OutputResourcesUtil.java
+++ b/src/main/java/tectonicus/util/OutputResourcesUtil.java
@@ -545,7 +545,7 @@ public class OutputResourcesUtil {
                                 final String entryKey = entry.getKey();
                                 final ItemModel itemModel = entry.getValue();
                                 final ItemModel ultimatePredecessorModel = itemRegistry.findUltimatePredecessor(itemModel);
-                                final File outFile = new File(args.getOutputDir(), "Images/Items/" + entryKey + ".png");
+                                File outFile = new File(args.getOutputDir(), "Images/Items/" + entryKey + ".png");
 
                                 System.out.print("\tRendering icon for: " + entryKey + "                    \r"); //prints a carriage return after line
                                 log.trace("\tRendering icon for: " + entryKey);
@@ -611,8 +611,15 @@ public class OutputResourcesUtil {
                                                                         }
                                                                 }
                                                         }
-                                                                                                                
-                                                        composited.getGraphics().drawImage(texture, 0, 0, null);
+                                                              
+                                                        if (layer.getKey().equals("layer0") && textureId.contains("leather_")) {
+                                                                // Split the leather armor icon into base layer and overlay so that the base layer
+                                                                // can be coloured in CSS due to the colour not being known at this time.
+                                                                writeImage(texture, 16, 16, outFile);
+                                                                outFile = new File(args.getOutputDir(), "Images/Items/" + entryKey + "_overlay.png");
+                                                        } else {
+                                                                composited.getGraphics().drawImage(texture, 0, 0, null);
+                                                        }
                                                 }
                                                 writeImage(composited, 16, 16, outFile);
                                                 continue;

--- a/src/main/java/tectonicus/util/OutputResourcesUtil.java
+++ b/src/main/java/tectonicus/util/OutputResourcesUtil.java
@@ -557,20 +557,8 @@ public class OutputResourcesUtil {
                                         continue;
                                 }
                                 
-                                // Fix for buttons, fences and pistons
-                                if (modelName.contains("_inventory")) {
-                                        modelName = StringUtils.removeEnd(modelName, "_inventory");
-                                        if (modelName.contains("fence") || modelName.contains("wall")) {
-                                                modelName += "_post";
-                                        }
-                                }
-                                
-                                // Some items need special handling. Namely beds, fence/wall posts and builtin entities
-                                if (modelName.endsWith("_post")) {
-                                        // TODO: build a fence segment with 2 posts or wall segment with 1 post
-                                        //continue;
-                                }
-                                if (modelName.endsWith("builtin/entity")) {
+                                // Some items need special handling. Namely beds and builtin entities
+                                if (modelName.endsWith("builtin/entity")){
                                         modelName = "minecraft:" + entryKey;
                                         
                                         if (entryKey.endsWith("_bed")) {
@@ -578,15 +566,7 @@ public class OutputResourcesUtil {
                                                 continue;
                                         }
                                         
-                                        List<Map<String, ArrayList<Float>>> transforms = itemRegistry.getTransformsList(itemModel);
-
-                                        // All the items are a bit small out of the box for some reason, so add our own tranform to make them larger
-                                        HashMap<String, ArrayList<Float>> transform = new HashMap<>();
-                                        transform.put("scale", new ArrayList<>(List.of(1.5f, 1.5f, 1.5f)));
-                                        transforms.add(transform);
-                                        
-                                        // TODO: chest and ender chest still do not render, same as chorus plant and shield
-                                        
+                                        List<Map<String, ArrayList<Float>>> transforms = itemRegistry.getTransformsList(itemModel);                                        
                                         itemRenderer.renderItem(outFile, blockTypeRegistry, texturePack, modelName, transforms);
                                         continue;
                                 }
@@ -605,8 +585,15 @@ public class OutputResourcesUtil {
                                         }
                                 }
                                 
+                                // Inventory block models are not loaded in the registry because they do not have a block state. Let's load them manually
+                                if (modelName.contains("_inventory")) {
+                                        var model = blockRegistry.loadModel(modelName, "", new HashMap<>(), null);
+                                        itemRenderer.renderInventoryBlockModel(outFile, blockRegistry, texturePack, model);
+                                        continue;
+                                }
+                                
                                 // Rest of the items
-                                itemRenderer.renderBlockModelName(outFile, blockRegistry, texturePack, modelName);
+                                itemRenderer.renderInventoryBlockModel(outFile, blockRegistry, texturePack, modelName);
 			}
                         System.out.println();
 		} catch (Exception e) {

--- a/src/main/java/tectonicus/world/World.java
+++ b/src/main/java/tectonicus/world/World.java
@@ -1259,7 +1259,7 @@ public class World implements BlockContext
 
 		if(!isFoliage && (biome == BiomesOld.DARK_FOREST || biome == BiomesOld.DARK_FOREST_HILLS)) {
 			Colour4f origColor = getTintColorFromBiomeTextures(BiomeUtils.normalize(adjTemp), BiomeUtils.normalize(adjRainfall), false);
-			return new Colour4f((origColor.toInt() & 16711422) + 2634762 >> 1);
+			return new Colour4f((origColor.toRgb() & 16711422) + 2634762 >> 1);
 		} else {
 			return getTintColorFromBiomeTextures(BiomeUtils.normalize(adjTemp), BiomeUtils.normalize(adjRainfall), isFoliage);
 		}

--- a/src/main/resources/containers.js
+++ b/src/main/resources/containers.js
@@ -186,8 +186,8 @@ function renderMinecraftText(text, className) {
 
 function createChestPopup(chest) {
         let markerPopup = chest.large
-                ? '<div class="chest_container large"><div class="chest_scaler"><img class="chest large_chest" src="Images/LargeChest.png"/>'
-                : '<div class="chest_container"><div class="chest_scaler"><img class="chest" src="Images/SmallChest.png"/>';
+                ? '<div class="chest_container large"><div class="chest_scaler"><img src="Images/LargeChest.png" />'
+                : '<div class="chest_container"><div class="chest_scaler"><img src="Images/SmallChest.png" />';
 
         markerPopup += renderMinecraftText(chest.name, 'chest_name');
 
@@ -241,7 +241,7 @@ function createChestPopup(chest) {
                 let pngName = getPngName(item, itemId);
                 
                 markerPopup += '<div class="item" style="top: ' + top + 'px; left: ' + left + 'px;">';
-                markerPopup += '<img src="Images/Items/' + pngName + '.png" />';
+                markerPopup += '<img src="Images/Items/' + pngName + '.png" onload="checkImageSize(this)" />';
                 
                 markerPopup += getColorLayer(intToHTMLColor(item?.color), itemId);
                 markerPopup += getLeatherOverlay(item, itemId, pngName);
@@ -345,7 +345,13 @@ function getLeatherOverlay(item, itemId, pngName) {
         if (itemId === 'leather_boots' || itemId === 'leather_chestplate' || itemId === 'leather_helmet' || itemId === 'leather_leggings') {
                 let overlayId = pngName + '_overlay';
                 result += '<img src="Images/Items/' + overlayId + '.png" />';
-                result += getEnchantmentGlint(item, overlayId, true, overlayId);
+                result += getEnchantmentGlint(item, overlayId, overlayId);
         }
         return result;
+}
+
+function checkImageSize(image) {
+        if (image.naturalWidth !== 16 || image.naturalHeight !== 16) {
+                image.classList.add('item_3d');
+        }
 }

--- a/src/main/resources/containers.js
+++ b/src/main/resources/containers.js
@@ -199,19 +199,6 @@ function createChestPopup(chest) {
                 const itemDescKey = `item.${namespace}.${itemId}.desc`;
                 const blockKey = `block.${namespace}.${itemId}`;
 
-                let itemNameAndDescription = itemId;
-                let isItem = true; // Assume we have an item
-                if (localizations) {
-                        if (localizations[itemKey]) {
-                                itemNameAndDescription = localizations[itemKey];
-                        } else if (localizations[blockKey]) {
-                                itemNameAndDescription = localizations[blockKey];
-                                isItem = false;
-                        } else {
-                                isItem = false;
-                        }
-                }
-
                 let additionalItemNameCssClass = '';
                 if (item.enchantments) {
                         additionalItemNameCssClass = ' enchanted';
@@ -220,6 +207,7 @@ function createChestPopup(chest) {
                         additionalItemNameCssClass = ' ' + colorizedNames[itemId];
                 }
 
+                let itemNameAndDescription;
                 if (item.customName) {
                         // Parse custom name. Possible values if matched:
                         //      {text:Custom name}
@@ -235,7 +223,8 @@ function createChestPopup(chest) {
                                 itemNameAndDescription = renderMinecraftText(localize(item.customName), 'name italic' + additionalItemNameCssClass);
                         }
                 } else {
-                        itemNameAndDescription = renderMinecraftText(localize(itemNameAndDescription), 'name' + additionalItemNameCssClass);
+                        itemNameAndDescription = localize(itemKey, localize(blockKey, itemId));
+                        itemNameAndDescription += renderMinecraftText(itemNameAndDescription, 'name' + additionalItemNameCssClass);
                 }
 
                 itemNameAndDescription += renderMinecraftText(localize(itemDescKey, null));
@@ -259,18 +248,15 @@ function createChestPopup(chest) {
                 const left = 8+18*col;
 
                 markerPopup += '<div class="item" style="top: ' + top + 'px; left: ' + left + 'px;">';
-                markerPopup += '<img src="Images/Items/' + (isItem ? pngName : 'barrier') + '.png" />';
+                markerPopup += '<img src="Images/Items/' + pngName + '.png" />';
                 
                 markerPopup += getColorLayer(intToHTMLColor(item?.color), itemId);
                 markerPopup += getLeatherOverlay(item, itemId);
                 markerPopup += getArmorTrimOverlay(item, itemId);
-                markerPopup += getEnchantmentGlint(item, itemId, isItem, pngName);
+                markerPopup += getEnchantmentGlint(item, itemId, pngName);
 
                 if (item.count > 1) {
                         markerPopup += renderMinecraftText(item.count.toString(), 'item_count');
-                }
-                if (!isItem) {
-                        markerPopup += renderMinecraftText(itemId, 'item_name');
                 }
 
                 markerPopup += '<div class=item_description>' + itemNameAndDescription + '</div></div>';
@@ -324,10 +310,10 @@ function getEnchantmentsDescription(item) {
         return result;
 }
 
-function getEnchantmentGlint(item, itemId, isItem, pngName) { // TODO: remove isItem and pngName after block items have their icons and placeholder icon is unnecessary
+function getEnchantmentGlint(item, itemId, pngName) {
         if (item.enchantments || itemId === 'enchanted_golden_apple')
         {
-                return '<div class="enchanted_glint" style="-webkit-mask-image: url(\'Images/Items/' + (isItem ? pngName : 'barrier') + '\.png\'); mask-image: url(\'Images/Items/' + (isItem ? pngName : 'barrier') + '.png\');"></div>';
+                return '<div class="enchanted_glint" style="-webkit-mask-image: url(\'Images/Items/' + pngName + '\.png\'); mask-image: url(\'Images/Items/' + pngName + '.png\');"></div>';
         }
         return '';
 }

--- a/src/main/resources/containers.js
+++ b/src/main/resources/containers.js
@@ -232,19 +232,19 @@ function createChestPopup(chest) {
                 itemNameAndDescription += getEnchantmentsDescription(item);
                 itemNameAndDescription += item.color ? renderMinecraftText(localize('item.dyed'), 'italic') : '';
 
-                let pngName = getPngName(item, itemId);
-
                 const row = Math.floor(item.slot/9);
                 const col = item.slot%9;
 
                 const top = 18+18*row;
                 const left = 8+18*col;
 
-                const is3dItem = localizations && localizations[blockKey];
+                let pngName = getPngName(item, itemId);
                 
-                markerPopup += '<div class="item ' + (is3dItem ? '3d_item' : '') + '" style="top: ' + top + 'px; left: ' + left + 'px;">';
+                markerPopup += '<div class="item" style="top: ' + top + 'px; left: ' + left + 'px;">';
                 markerPopup += '<img src="Images/Items/' + pngName + '.png" />';
                 
+                markerPopup += getColorLayer(intToHTMLColor(item?.color), itemId);
+                markerPopup += getLeatherOverlay(item, itemId, pngName);
                 markerPopup += getEnchantmentGlint(item, itemId, pngName);
 
                 if (item.count > 1) {
@@ -319,4 +319,33 @@ function getEnchantmentGlint(item, itemId, pngName) {
                 return '<div class="enchanted_glint" style="-webkit-mask-image: url(\'Images/Items/' + pngName + '\.png\'); mask-image: url(\'Images/Items/' + pngName + '.png\');"></div>';
         }
         return '';
+}
+
+function intToHTMLColor(colorCode) {
+        if (!colorCode) {
+                return null;
+        }
+        var hexColor = colorCode.toString(16);
+        while (hexColor.length < 6) {
+                hexColor = "0" + hexColor;
+        }
+        return "#" + hexColor;
+}
+
+function getColorLayer(color, itemId) {
+        if (color || itemId.indexOf('leather_') >= 0) {
+                color ??= 'rgb(106, 64, 41)';
+                return '<div class="color_layer" style="background-color: ' + color + '; mask-image: url(\'Images/Items/' + itemId + '.png\');"></div>';
+        }
+        return '';
+}
+
+function getLeatherOverlay(item, itemId, pngName) {
+        let result = '';
+        if (itemId === 'leather_boots' || itemId === 'leather_chestplate' || itemId === 'leather_helmet' || itemId === 'leather_leggings') {
+                let overlayId = pngName + '_overlay';
+                result += '<img src="Images/Items/' + overlayId + '.png" />';
+                result += getEnchantmentGlint(item, overlayId, true, overlayId);
+        }
+        return result;
 }

--- a/src/main/resources/containers.js
+++ b/src/main/resources/containers.js
@@ -198,7 +198,7 @@ function createChestPopup(chest) {
                 const itemKey = `item.${namespace}.${itemId}`;
                 const itemDescKey = `item.${namespace}.${itemId}.desc`;
                 const blockKey = `block.${namespace}.${itemId}`;
-
+                
                 let additionalItemNameCssClass = '';
                 if (item.enchantments) {
                         additionalItemNameCssClass = ' enchanted';
@@ -247,7 +247,9 @@ function createChestPopup(chest) {
                 const top = 18+18*row;
                 const left = 8+18*col;
 
-                markerPopup += '<div class="item" style="top: ' + top + 'px; left: ' + left + 'px;">';
+                const is3dItem = localizations && localizations[blockKey];
+                
+                markerPopup += '<div class="item ' + (is3dItem ? '3d_item' : '') + '" style="top: ' + top + 'px; left: ' + left + 'px;">';
                 markerPopup += '<img src="Images/Items/' + pngName + '.png" />';
                 
                 markerPopup += getColorLayer(intToHTMLColor(item?.color), itemId);

--- a/src/main/resources/containers.js
+++ b/src/main/resources/containers.js
@@ -232,14 +232,7 @@ function createChestPopup(chest) {
                 itemNameAndDescription += getEnchantmentsDescription(item);
                 itemNameAndDescription += item.color ? renderMinecraftText(localize('item.dyed'), 'italic') : '';
 
-                let pngName = itemId;
-                if (itemId === 'compass' || itemId === 'clock' || itemId === 'recovery_compass') {
-                        // Choose 1st frame for animated items
-                        pngName += '_00';
-                }
-                if (itemId === 'enchanted_golden_apple') {
-                        pngName = 'golden_apple';
-                }
+                let pngName = getPngName(item, itemId);
 
                 const row = Math.floor(item.slot/9);
                 const col = item.slot%9;
@@ -252,9 +245,6 @@ function createChestPopup(chest) {
                 markerPopup += '<div class="item ' + (is3dItem ? '3d_item' : '') + '" style="top: ' + top + 'px; left: ' + left + 'px;">';
                 markerPopup += '<img src="Images/Items/' + pngName + '.png" />';
                 
-                markerPopup += getColorLayer(intToHTMLColor(item?.color), itemId);
-                markerPopup += getLeatherOverlay(item, itemId);
-                markerPopup += getArmorTrimOverlay(item, itemId);
                 markerPopup += getEnchantmentGlint(item, itemId, pngName);
 
                 if (item.count > 1) {
@@ -267,6 +257,17 @@ function createChestPopup(chest) {
         markerPopup += '</div></div>';
         
         return markerPopup;
+}
+
+function getPngName(item, itemId) {
+        let pngName = itemId;
+        
+        if (item.trim) {
+                const [namespace, material] = item.trim.material.split(":");
+                pngName += '_' + material + '_trim';
+        }
+        
+        return pngName;
 }
 
 function getTrimDescription(item) {
@@ -318,80 +319,4 @@ function getEnchantmentGlint(item, itemId, pngName) {
                 return '<div class="enchanted_glint" style="-webkit-mask-image: url(\'Images/Items/' + pngName + '\.png\'); mask-image: url(\'Images/Items/' + pngName + '.png\');"></div>';
         }
         return '';
-}
-
-function intToHTMLColor(colorCode) {
-        if (!colorCode) {
-                return null;
-        }
-        var hexColor = colorCode.toString(16);
-        while (hexColor.length < 6) {
-                hexColor = "0" + hexColor;
-        }
-        return "#" + hexColor;
-}
-
-function getColorLayer(color, itemId) {
-        if (color || itemId.indexOf('leather_') >= 0) {
-                color ??= 'rgb(106, 64, 41)';
-                return '<div class="color_layer" style="background-color: ' + color + '; mask-image: url(\'Images/Items/' + itemId + '.png\');"></div>';
-        }
-        return '';
-}
-
-function getLeatherOverlay(item, itemId) {
-        let result = '';
-        if (itemId === 'leather_boots' || itemId === 'leather_chestplate' || itemId === 'leather_helmet' || itemId === 'leather_leggings') {
-                let overlayId = itemId + '_overlay';
-                result += '<img src="Images/Items/' + overlayId + '.png" />';
-                result += getEnchantmentGlint(item, overlayId, true, overlayId);
-        }
-        return result;
-}
-
-function getArmorTrimOverlay(item, itemId) {
-        let result = '';
-        if (item.trim) {
-                const [material, armorPiece] = itemId.split("_");
-                if (armorPiece === 'boots' || armorPiece === 'chestplate' || armorPiece === 'helmet' || armorPiece === 'leggings') {
-                        let color;
-                        
-                        switch(item.trim.material) {
-                                case 'minecraft:amethyst':
-                                        color = '#d393ff';
-                                        break;
-                                case 'minecraft:copper':
-                                        color = '#ff9474';
-                                        break;
-                                case 'minecraft:diamond':
-                                        color = '#71deff';
-                                        break;
-                                case 'minecraft:emerald':
-                                        color = '#43ff83';
-                                        break;
-                                case 'minecraft:gold':
-                                        color = '#ffe300';
-                                        break;
-                                case 'minecraft:iron':
-                                        color = '#d2d2d2';
-                                        break;
-                                case 'minecraft:lapis':
-                                        color = '#3c6bc6';
-                                        break;
-                                case 'minecraft:netherite':
-                                        color = '#666666';
-                                        break;
-                                case 'minecraft:quartz':
-                                        color = '#ffffff';
-                                        break;
-                                case 'minecraft:redstone':
-                                        color = '#ff0000';
-                                        break;
-                        }
-                    
-                        result += '<img src="Images/Items/' + armorPiece + '_trim.png" />';
-                        result += getColorLayer(color, armorPiece + '_trim');
-                }
-        }
-        return result;
 }

--- a/src/main/resources/tectonicusStyles.css
+++ b/src/main/resources/tectonicusStyles.css
@@ -51,13 +51,24 @@ html, body, #map {
         position: absolute;
 }
 
-.3d_item img {
-        image-rendering: auto;
-}
-
 .item img {
         width: 16px;
         height: 16px;
+}
+
+.item img ~ img {
+        position: absolute;
+        top: 0;
+        left: 0;
+}
+
+.item .color_layer {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 16px;
+        height: 16px;
+        mix-blend-mode: multiply;
 }
 
 @keyframes enchanted_glint {

--- a/src/main/resources/tectonicusStyles.css
+++ b/src/main/resources/tectonicusStyles.css
@@ -60,21 +60,6 @@ html, body, #map {
         height: 16px;
 }
 
-.item img ~ img {
-        position: absolute;
-        top: 0;
-        left: 0;
-}
-
-.item .color_layer {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 16px;
-        height: 16px;
-        mix-blend-mode: multiply;
-}
-
 @keyframes enchanted_glint {
         0% {
                 background-position-x: 0px;

--- a/src/main/resources/tectonicusStyles.css
+++ b/src/main/resources/tectonicusStyles.css
@@ -51,6 +51,10 @@ html, body, #map {
         position: absolute;
 }
 
+.3d_item img {
+        image-rendering: auto;
+}
+
 .item img {
         width: 16px;
         height: 16px;

--- a/src/main/resources/tectonicusStyles.css
+++ b/src/main/resources/tectonicusStyles.css
@@ -1,281 +1,287 @@
 body {
-	padding: 0;
-	margin: 0;
+    padding: 0;
+    margin: 0;
 }
+
 html, body, #map {
-	height: 100%;
-	width: 100%;
+    height: 100%;
+    width: 100%;
 }
 
 .compass.leaflet-control-custom {
-	clear: none;
+    clear: none;
 }
 
 .button.leaflet-control-custom {
-	margin-left: -2px;
-	clear: none;
+    margin-left: -2px;
+    clear: none;
 }
 
 .leaflet-control-layers-expanded:hover {
-	border-color: rgb(137, 132, 209);
+    border-color: rgb(137, 132, 209);
 }
 
 .button:hover {
-	border-color: rgb(137, 132, 209);
+    border-color: rgb(137, 132, 209);
 }
 
 .center {
-	text-align: center;
+    text-align: center;
 }
 
 .chest_container {
-        font-size: 0;
-        line-height: 0;
-        width: 528px;                   /* Do not rely on scale and set size explicitly so that leaflet popup can adjust its size properly */
-        height: 234px;                  /* These should therefore be set to scale*chest_image_size */
+    font-size: 0;
+    line-height: 0;
+    width: 528px; /* Do not rely on scale and set size explicitly so that leaflet popup can adjust its size properly */
+    height: 234px; /* These should therefore be set to scale*chest_image_size */
 }
 
-.chest_container.large {
+    .chest_container.large {
         height: 396px;
-}
+    }
 
 .chest_scaler {
-        image-rendering: pixelated;     /* Use neirest neighbour to keep pixelated look */
-        scale: 3;                       /* Use integer scale for best look */
-        position: absolute;
-        transform-origin: top left;
-        width: 0;
+    image-rendering: pixelated; /* Use neirest neighbour to keep pixelated look */
+    scale: 3; /* Use integer scale for best look */
+    position: absolute;
+    transform-origin: top left;
+    width: 0;
 }
 
-.chest_scaler>div {
+    .chest_scaler > div {
         position: absolute;
-}
+    }
 
 .item img {
-        width: 16px;
-        height: 16px;
+    width: 16px;
+    height: 16px;
 }
 
-.item img ~ img {
+    .item img.item_3d {
+        image-rendering: auto;
+    }
+
+    .item img ~ img {
         position: absolute;
         top: 0;
         left: 0;
-}
+    }
 
 .item .color_layer {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 16px;
-        height: 16px;
-        mix-blend-mode: multiply;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 16px;
+    height: 16px;
+    mix-blend-mode: multiply;
 }
 
 @keyframes enchanted_glint {
-        0% {
-                background-position-x: 0px;
-                background-position-y: 0px;
-        }
-        100% {
-                background-position-x: -256px;
-                background-position-y: -384px;
-        }
+    0% {
+        background-position-x: 0px;
+        background-position-y: 0px;
+    }
+
+    100% {
+        background-position-x: -256px;
+        background-position-y: -384px;
+    }
 }
 
 .item .enchanted_glint {
-        width: 16px;
-        height: 16px;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        background-image: url('../Images/EnchantedGlint.png');
-        mix-blend-mode: color-dodge;
-        animation: enchanted_glint 60s linear infinite;
+    width: 16px;
+    height: 16px;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background-image: url('../Images/EnchantedGlint.png');
+    mix-blend-mode: color-dodge;
+    animation: enchanted_glint 60s linear infinite;
 }
 
 .item .item_description {
-        position: absolute;
-        left: 19px;
-        top: -6px;
-        visibility: collapse;
-        background: rgba(0, 0, 0, 0.9);
-        z-index: 1000;
-        border-radius: 2px;
-        border: solid 1px rgba(0, 0, 0, 0.9);
-        padding: 2px 3px 3px 3px;
-        outline: solid 1px #280459;
-        outline-offset: -2px;
+    position: absolute;
+    left: 19px;
+    top: -6px;
+    visibility: collapse;
+    background: rgba(0, 0, 0, 0.9);
+    z-index: 1000;
+    border-radius: 2px;
+    border: solid 1px rgba(0, 0, 0, 0.9);
+    padding: 2px 3px 3px 3px;
+    outline: solid 1px #280459;
+    outline-offset: -2px;
 }
 
 .item:hover .item_description {
-        visibility: visible;
+    visibility: visible;
 }
 
 .item_description .mc_text_container {
-        position: relative;
-        width: max-content;
-        margin-top: 2px;
+    position: relative;
+    width: max-content;
+    margin-top: 2px;
 }
 
 .item_description .name + * {
-        margin-top: 4px;
+    margin-top: 4px;
 }
 
 .item_description .mc_char {
-        position: relative;
-        filter: drop-shadow(1px 1px rgb(41, 41, 41));
+    position: relative;
+    filter: drop-shadow(1px 1px rgb(41, 41, 41));
 }
 
-.item_description .mc_char::before {
+    .item_description .mc_char::before {
         background: #a8a8a8;
-}
+    }
 
 .item_description .name .mc_char {
-        filter: drop-shadow(1px 1px rgb(70, 70, 70));
+    filter: drop-shadow(1px 1px rgb(70, 70, 70));
 }
 
-.item_description .name .mc_char::before {
+    .item_description .name .mc_char::before {
         background: #fcfcfc;
-}
+    }
 
 .item_description .enchanted .mc_char {
-        filter: drop-shadow(1px 1px rgb(21, 62, 62));
+    filter: drop-shadow(1px 1px rgb(21, 62, 62));
 }
 
-.item_description .enchanted .mc_char::before {
+    .item_description .enchanted .mc_char::before {
         background: #54fcfc;
-}
+    }
 
 .item_description .yellow .mc_char {
-        filter: drop-shadow(1px 1px rgb(62, 62, 21));
+    filter: drop-shadow(1px 1px rgb(62, 62, 21));
 }
 
-.item_description .yellow .mc_char::before {
+    .item_description .yellow .mc_char::before {
         background: #fcfc54;
-}
+    }
 
 .item_description .purple .mc_char {
-        filter: drop-shadow(1px 1px rgb(62, 21, 62));
+    filter: drop-shadow(1px 1px rgb(62, 21, 62));
 }
 
-.item_description .purple .mc_char::before {
+    .item_description .purple .mc_char::before {
         background: #fc54fc;
-}
+    }
 
 .item_description .orange .mc_char {
-        filter: drop-shadow(1px 1px rgb(62, 41, 0));
+    filter: drop-shadow(1px 1px rgb(62, 41, 0));
 }
 
-.item_description .orange .mc_char::before {
+    .item_description .orange .mc_char::before {
         background: #fca800;
-}
+    }
 
 .item_description .curse .mc_char {
-        filter: drop-shadow(1px 1px rgb(62, 21, 21));
+    filter: drop-shadow(1px 1px rgb(62, 21, 21));
 }
 
-.item_description .curse .mc_char::before {
+    .item_description .curse .mc_char::before {
         background: #fc5454;
-}
+    }
 
 .item_description .amethyst .mc_char {
-        filter: drop-shadow(1px 1px rgb(38, 23, 48));
+    filter: drop-shadow(1px 1px rgb(38, 23, 48));
 }
 
-.item_description .amethyst .mc_char::before {
+    .item_description .amethyst .mc_char::before {
         background: #985bc4;
-}
+    }
 
 .item_description .copper .mc_char {
-        filter: drop-shadow(1px 1px rgb(44, 26, 19));
+    filter: drop-shadow(1px 1px rgb(44, 26, 19));
 }
 
-.item_description .copper .mc_char::before {
+    .item_description .copper .mc_char::before {
         background: #b2674c;
-}
+    }
 
 .item_description .diamond .mc_char {
-        filter: drop-shadow(1px 1px rgb(27, 58, 51));
+    filter: drop-shadow(1px 1px rgb(27, 58, 51));
 }
 
-.item_description .diamond .mc_char::before {
+    .item_description .diamond .mc_char::before {
         background: #6de9cf;
-}
+    }
 
 .item_description .emerald .mc_char {
-        filter: drop-shadow(1px 1px rgb(4, 39, 13));
+    filter: drop-shadow(1px 1px rgb(4, 39, 13));
 }
 
-.item_description .emerald .mc_char::before {
+    .item_description .emerald .mc_char::before {
         background: #119e35;
-}
+    }
 
 .item_description .gold .mc_char {
-        filter: drop-shadow(1px 1px rgb(54, 43, 11));
+    filter: drop-shadow(1px 1px rgb(54, 43, 11));
 }
 
-.item_description .gold .mc_char::before {
+    .item_description .gold .mc_char::before {
         background: #dbaf2c;
-}
+    }
 
 .item_description .iron .mc_char {
-        filter: drop-shadow(1px 1px rgb(58, 58, 58));
+    filter: drop-shadow(1px 1px rgb(58, 58, 58));
 }
 
-.item_description .iron .mc_char::before {
+    .item_description .iron .mc_char::before {
         background: #e9e9e9;
-}
+    }
 
 .item_description .lapis .mc_char {
-        filter: drop-shadow(1px 1px rgb(16, 27, 37));
+    filter: drop-shadow(1px 1px rgb(16, 27, 37));
 }
 
-.item_description .lapis .mc_char::before {
+    .item_description .lapis .mc_char::before {
         background: #406d95;
-}
+    }
 
 .item_description .netherite .mc_char {
-        filter: drop-shadow(1px 1px rgb(24, 22, 22));
+    filter: drop-shadow(1px 1px rgb(24, 22, 22));
 }
 
-.item_description .netherite .mc_char::before {
+    .item_description .netherite .mc_char::before {
         background: #615758;
-}
+    }
 
 .item_description .quartz .mc_char {
-        filter: drop-shadow(1px 1px rgb(55, 52, 48));
+    filter: drop-shadow(1px 1px rgb(55, 52, 48));
 }
 
-.item_description .quartz .mc_char::before {
+    .item_description .quartz .mc_char::before {
         background: #e0d1c2;
-}
+    }
 
 .item_description .redstone .mc_char {
-        filter: drop-shadow(1px 1px rgb(37, 5, 1));
+    filter: drop-shadow(1px 1px rgb(37, 5, 1));
 }
 
-.item_description .redstone .mc_char::before {
+    .item_description .redstone .mc_char::before {
         background: #951607;
-}
+    }
 
 .item_description .italic {
-        margin-left: 1px;
-        margin-right: 1px;
-        transform: skew(-20deg, 0);
+    margin-left: 1px;
+    margin-right: 1px;
+    transform: skew(-20deg, 0);
 }
 
 .mc_text_container {
-        position: absolute;
+    position: absolute;
 }
 
 .mc_char {
-        width: 6px;
-        height: 8px;
-        display: inline-block;
-        filter: drop-shadow(1px 1px rgb(62, 62, 62));
+    width: 6px;
+    height: 8px;
+    display: inline-block;
+    filter: drop-shadow(1px 1px rgb(62, 62, 62));
 }
 
-.mc_char::before {
+    .mc_char::before {
         content: '';
         position: relative;
         top: 0;
@@ -286,33 +292,33 @@ html, body, #map {
         display: inherit;
         width: inherit;
         height: inherit;
-}
+    }
 
 .item_count {
-        right: 0;
-        bottom: 0;
+    right: 0;
+    bottom: 0;
 }
 
 .item_name {
-        position: absolute;
-        top: 0;
-        left: 0;
-        scale: 33.33%;
-        width: 300%;
-        transform-origin: top left;
+    position: absolute;
+    top: 0;
+    left: 0;
+    scale: 33.33%;
+    width: 300%;
+    transform-origin: top left;
 }
 
 .chest_name {
-        top: 6px;
-        left: 7px;
-        width: 162px;
-        height: 9px;
+    top: 6px;
+    left: 7px;
+    width: 162px;
+    height: 9px;
 }
 
-.chest_name .mc_char {
+    .chest_name .mc_char {
         filter: unset;
-}
+    }
 
-.chest_name .mc_char::before {
-        background: #3f3f3f;
-}
+        .chest_name .mc_char::before {
+            background: #3f3f3f;
+        }


### PR DESCRIPTION
Hi, I finished the rendering of block items. All the inventory icons are now rendered from the item model.

![Screenshot 2024-04-14 160425](https://github.com/tectonicus/tectonicus/assets/51075039/c5fb51e7-11ab-469b-a6d3-486a5e3a12be)

There are some issues though:
- chorus plant does not render and I have not been able to figure out why
- shields do not render. since they are builtin, they will have to be implemented as a block type
- banners, stairs, heads are incorrectly rotated/translated/scaled
- grass block, drip leafs, sculk sensors sometimes render with some faces missing

I have implemented the transforms, but the are weird. Some of them would fix rotation and scaling issues of banners, heads, etc., but some of the transforms  I do not understand. For example all the heads have defined translation along Y axis of 3 units, which would push them out of frame. I have decided to comment out the transforms for now.

The sculk sensors look like every time they are rendered, they look a little different. Like they are animated and I capture them at different times in the animation. And sometimes the missing faces are correctly rendered...

I might take a look at these issues, but I think I need a pause for some time :). For now this looks stable and should basically be done, so maybe it can already be merged to master.