### PR TITLE
changed bed.png back to Bed.png

### DIFF
--- a/src/main/java/tectonicus/util/OutputResourcesUtil.java
+++ b/src/main/java/tectonicus/util/OutputResourcesUtil.java
@@ -726,7 +726,7 @@ public class OutputResourcesUtil {
 				itemRenderer.renderBlock(new File(exportDir, "Images/Chest.png"), registryOld, registry, texturePack, Block.CHEST, new BlockProperties(properties));
 			}
 
-			itemRenderer.renderBed(new File(exportDir, "Images/bed.png"), registryOld, texturePack);
+			itemRenderer.renderBed(new File(exportDir, "Images/Bed.png"), registryOld, texturePack);
 			itemRenderer.renderCompass(map, new File(exportDir, map.getId()+"/Compass.png"));
 			itemRenderer.renderPortal(new File(args.getOutputDir(), "Images/Portal.png"), registryOld, texturePack);
 			if (version.getNumVersion() >= VERSION_16.getNumVersion()) {

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -119,7 +119,7 @@ async function mainAsync()
         viewToggleControl = CreateToggleControl('views', 'Images/Picture.png', viewMarkers, viewsInitiallyVisible);
         signToggleControl = CreateToggleControl('signs', 'Images/Sign.png', signMarkers, signsInitiallyVisible);
         playerToggleControl = CreateToggleControl('players', 'Images/PlayerIcons/Tectonicus_Default_Player_Icon.png', playerMarkers, playersInitiallyVisible);
-        bedToggleControl = CreateToggleControl('beds', 'Images/bed.png', bedMarkers, bedsInitiallyVisible);
+        bedToggleControl = CreateToggleControl('beds', 'Images/Bed.png', bedMarkers, bedsInitiallyVisible);
         respawnAnchorToggleControl = CreateToggleControl('respawn anchors', 'Images/RespawnAnchor.png', respawnAnchorMarkers, respawnAnchorsInitiallyVisible);
         beaconToggleControl = CreateToggleControl('beacons', 'Images/beacon.png', beaconMarkers, beaconsInitiallyVisible);
         portalToggleControl = CreateToggleControl('portals', 'Images/Portal.png', portalMarkers, portalsInitiallyVisible);


### PR DESCRIPTION
Hi, I noticed the new beacon update and liked the idea, so wanted to try it. But after updating my map, the bed icon in the beds toggle button disappeared.

It was a bit of a head scratcher, because the icon file was present in the Images folder. But I noticed that I had Bed.png in the folder, while the HTML was linking to bed.png. Apparently for the longest time the icon was Bed.png, then it was changed to Items/red_bed.png in 192d884, and than back to bed.png in f30778e (but with lowercase b).

I was updating a map that was already rendered in the past and I had Bed.png already present. I render on Windows, so even though Tectonicus tried outputting bed.png, the name remained Bed.png, because apparently Windows is weird this way. One can not even rename a file and change only the letter case in explorer. The letter case remains, unles some other change to the file name is also made... :(

This would probably be OK if my map was hosted on Windows, because Bed.png and bed.png are the same file there. But after rendering I copy it to Linux VM where I host it. And there they are 2 different files and I get the 404 error...

I realize my use case is a bit convoluted with the mixing of Windows and Linux machines used for rendering and hosting, but perhaps not so much so that I would be alone with this issue. So if you agree, I think it would be best to keep the status quo and have the file named Bed.png so that if other people update their maps created in older versions of Tectonicus, they will not encounter this issue.