### PR TITLE
Container UI compatibility with 1.21.4 and 1.21.5

### DIFF
--- a/src/main/java/tectonicus/TileRenderer.java
+++ b/src/main/java/tectonicus/TileRenderer.java
@@ -28,6 +28,7 @@ import tectonicus.configuration.Configuration;
 import tectonicus.configuration.Configuration.RenderStyle;
 import tectonicus.configuration.ImageFormat;
 import tectonicus.configuration.Layer;
+import tectonicus.itemmodeldefinitionregistry.ItemModelDefinitionRegistry;
 import tectonicus.itemregistry.ItemRegistry;
 import tectonicus.rasteriser.Rasteriser;
 import tectonicus.rasteriser.RasteriserFactory;
@@ -312,8 +313,9 @@ public class TileRenderer
                 if (world == null) {
                         System.out.println("Unable to render. No map is defined in config.");
                 } else {
+                        ItemModelDefinitionRegistry itemModelDefinitionRegistry = new ItemModelDefinitionRegistry(world.getTexturePack());
                         ItemRegistry itemRegistry = new ItemRegistry(world.getTexturePack());
-                        outputInventoryItemIcons(config, rasteriser, world.getTexturePack(), world.getBlockTypeRegistry(), world.getModelRegistry(), itemRegistry);
+                        outputInventoryItemIcons(config, rasteriser, world.getTexturePack(), world.getBlockTypeRegistry(), world.getModelRegistry(), itemRegistry, itemModelDefinitionRegistry);
                         outputHtmlResources(world.getTexturePack(), playerIconAssembler, config, exportDir, numZoomLevels, tileWidth, tileHeight);
                 }
 		

--- a/src/main/java/tectonicus/itemmodeldefinitionregistry/ItemModelDefinition.java
+++ b/src/main/java/tectonicus/itemmodeldefinitionregistry/ItemModelDefinition.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Tectonicus contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.itemmodeldefinitionregistry;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ItemModelDefinition {
+	private String type;
+        private String base;
+	private String model;
+        private ItemModelDefinition innerModel; 
+        private String texture;
+        private String kind;
+        
+        @JsonProperty("model")
+	private void unpackModel(Object model) {
+		if (model instanceof String) {
+			this.model = (String) model;
+		} else if (model instanceof java.util.Map) {
+			@SuppressWarnings("unchecked")
+			java.util.Map<String, Object> modelMap = (java.util.Map<String, Object>) model;
+
+			innerModel = new ItemModelDefinition();
+			innerModel.setType((String) modelMap.get("type"));
+			innerModel.setTexture((String) modelMap.get("texture"));
+                        
+                        model = modelMap.get("model");
+			if (model != null) {
+				innerModel.unpackModel(model);
+			}
+		}
+	}
+        
+        public String getModelName() {
+                if (model != null) {
+                        return model;
+                }
+                if (innerModel != null) {
+                        return innerModel.getModelName();
+                }
+                return null;
+        }
+}

--- a/src/main/java/tectonicus/itemmodeldefinitionregistry/ItemModelDefinitionRegistry.java
+++ b/src/main/java/tectonicus/itemmodeldefinitionregistry/ItemModelDefinitionRegistry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Tectonicus contributors.  All rights reserved.
+ *
+ * This file is part of Tectonicus. It is subject to the license terms in the LICENSE file found in
+ * the top-level directory of this distribution.  The full list of project contributors is contained
+ * in the AUTHORS file found in the same location.
+ *
+ */
+
+package tectonicus.itemmodeldefinitionregistry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import tectonicus.texture.TexturePack;
+import tectonicus.texture.ZipStack;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class ItemModelDefinitionRegistry {
+	@Getter
+	private final Map<String, ItemModelDefinition> modelDefinitions = new HashMap<>();
+	private final ZipStack zips;
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	public ItemModelDefinitionRegistry(TexturePack texturePack) {
+		this.zips = texturePack.getZipStack();
+		log.info("Loading all item model definition json files...");
+		deserializeItemModels();
+		log.info("All item model definition json files loaded.");
+	}
+
+	public void deserializeItemModels() {
+		log.debug("Loading item model definition json from minecraft jar");
+		try (FileSystem fs = FileSystems.newFileSystem(Paths.get(zips.getBaseFileName()), null);
+			 DirectoryStream<Path> entries = Files.newDirectoryStream(fs.getPath("/assets/minecraft/items"))) {
+			deserializeItemModels(entries);
+		} catch (Exception e) {
+			log.error("Exception: ", e);
+		}
+	}
+
+	private void deserializeItemModels(DirectoryStream<Path> entries) throws IOException {
+		for (Path itemJsonFile : entries) {
+			ItemModelDefinition itemModel = OBJECT_MAPPER.readValue(Files.newBufferedReader(itemJsonFile, StandardCharsets.UTF_8), ItemModelDefinition.class);
+			String name = StringUtils.removeEnd(itemJsonFile.getFileName().toString(), ".json");
+			modelDefinitions.put(name, itemModel);
+		}
+	}
+}

--- a/src/main/java/tectonicus/itemmodeldefinitionregistry/ItemModelDefinitionRegistry.java
+++ b/src/main/java/tectonicus/itemmodeldefinitionregistry/ItemModelDefinitionRegistry.java
@@ -43,9 +43,13 @@ public class ItemModelDefinitionRegistry {
 
 	public void deserializeItemModels() {
 		log.debug("Loading item model definition json from minecraft jar");
-		try (FileSystem fs = FileSystems.newFileSystem(Paths.get(zips.getBaseFileName()), null);
-			 DirectoryStream<Path> entries = Files.newDirectoryStream(fs.getPath("/assets/minecraft/items"))) {
-			deserializeItemModels(entries);
+		try (FileSystem fs = FileSystems.newFileSystem(Paths.get(zips.getBaseFileName()), null)) {
+                        Path itemModelDefinitionsPath = fs.getPath("/assets/minecraft/items");
+                        if (Files.exists(itemModelDefinitionsPath)) {
+                                try (DirectoryStream<Path> entries = Files.newDirectoryStream(itemModelDefinitionsPath)) {
+                                        deserializeItemModels(entries);
+                                }                                
+                        }                            			
 		} catch (Exception e) {
 			log.error("Exception: ", e);
 		}

--- a/src/main/java/tectonicus/raw/RawChunk.java
+++ b/src/main/java/tectonicus/raw/RawChunk.java
@@ -792,20 +792,24 @@ public class RawChunk {
                 
                 if (enchantmentsTag != null) {
                         CompoundTag levelsTag = NbtUtil.getChild(enchantmentsTag, "levels", CompoundTag.class);
-                        if (levelsTag != null) {
-                                List<EnchantmentTag> enchantments = new ArrayList<>();
+                        
+                        if (levelsTag == null) {
+                                // From 1.21.5, simplified format is used, where levels field is inlined to top-level
+                                levelsTag = enchantmentsTag;
+                        } 
 
-                                for (var levelTagId : levelsTag.getValue().keySet()) {                                                
-                                        IntTag levelTag = NbtUtil.getChild(levelsTag, levelTagId, IntTag.class);
-                                        if (levelTag != null) {
-                                                enchantments.add(new EnchantmentTag(levelTagId, levelTag.getValue()));
-                                        }
+                        List<EnchantmentTag> enchantments = new ArrayList<>();
+
+                        for (var levelTagId : levelsTag.getValue().keySet()) {                                                
+                                IntTag levelTag = NbtUtil.getChild(levelsTag, levelTagId, IntTag.class);
+                                if (levelTag != null) {
+                                        enchantments.add(new EnchantmentTag(levelTagId, levelTag.getValue()));
                                 }
-
-                                components.add(isStoredEnchantments
-                                        ? new StoredEnchantmentsTag(enchantments)
-                                        : new EnchantmentsTag(enchantments));
                         }
+
+                        components.add(isStoredEnchantments
+                                ? new StoredEnchantmentsTag(enchantments)
+                                : new EnchantmentsTag(enchantments));
                 }
                 
                 CompoundTag trimTag = NbtUtil.getChild(componentsTag, "minecraft:trim", CompoundTag.class);

--- a/src/main/java/tectonicus/util/OutputResourcesUtil.java
+++ b/src/main/java/tectonicus/util/OutputResourcesUtil.java
@@ -29,6 +29,8 @@ import tectonicus.configuration.ImageFormat;
 import tectonicus.configuration.Layer;
 import tectonicus.configuration.filter.PlayerFilter;
 import tectonicus.configuration.filter.SignFilterType;
+import tectonicus.itemmodeldefinitionregistry.ItemModelDefinition;
+import tectonicus.itemmodeldefinitionregistry.ItemModelDefinitionRegistry;
 import tectonicus.itemregistry.ItemModel;
 import tectonicus.itemregistry.ItemRegistry;
 import tectonicus.rasteriser.Rasteriser;
@@ -594,7 +596,7 @@ public class OutputResourcesUtil {
                 return result;
         }
 
-	public static void outputInventoryItemIcons(Configuration args, Rasteriser rasteriser, TexturePack texturePack, BlockTypeRegistry blockTypeRegistry, BlockRegistry blockRegistry, ItemRegistry itemRegistry) {
+	public static void outputInventoryItemIcons(Configuration args, Rasteriser rasteriser, TexturePack texturePack, BlockTypeRegistry blockTypeRegistry, BlockRegistry blockRegistry, ItemRegistry itemRegistry, ItemModelDefinitionRegistry itemModelDefinitionRegistry) {
 		log.info("Rendering icons for inventory items");
 		if (texturePack.getVersion().getNumVersion() <= VERSION_12.getNumVersion()) { //A hack to skip rendering icons if the resource pack is for 1.12 or older
 			log.info("Skipping icon rendering. Chest items are supported for 1.13 and newer.");
@@ -606,6 +608,31 @@ public class OutputResourcesUtil {
 			File itemIconDir = new File(args.getOutputDir(), "Images/Items/");
 			Files.createDirectories(itemIconDir.toPath());
 			
+                        for (Map.Entry<String, ItemModelDefinition> entry : itemModelDefinitionRegistry.getModelDefinitions().entrySet()) {
+                                final String entryKey = entry.getKey();
+				final ItemModelDefinition itemModelDefinition = entry.getValue();
+                                File outFile = new File(itemIconDir, entryKey + ".png");
+
+                                System.out.print("\tRendering icon for: " + entryKey + "                    \r"); //prints a carriage return after line
+                                log.trace("\tRendering icon for: " + entryKey);
+
+                                String modelName = itemModelDefinition.getModelName();
+                                
+                                if (modelName == null) {
+                                    continue;
+                                }
+                                
+                                if (modelName.startsWith("minecraft:block")) {
+                                        itemRenderer.renderInventoryBlockModel(outFile, blockRegistry, texturePack, modelName);
+                                }
+                                else if (modelName.startsWith("minecraft:item")) {
+                                        // We should get entry from itemRegistry and render 2d texture item.
+                                        
+                                        // We do not need to do anything though, since all items from itemRegistry are iterated through and rendered below.
+                                        // This also ensures compatibility with pre-1.21.4 versions
+                                }
+                        }
+                        
 			for (Map.Entry<String, ItemModel> entry : itemRegistry.getModels().entrySet()) {
 				final String entryKey = entry.getKey();
 				final ItemModel itemModel = entry.getValue();


### PR DESCRIPTION
Hi, I have made fixes to container inventory UI. It was broken because of changes in NBT format and introduction of "item model definitions" in last 2 updates.